### PR TITLE
Add slightly more detail to pre-click summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
         <h3>Usability</h3>
 
         <details>
-          <summary>Sandstorm is the easiest way there has ever been to run a server. Install apps as easily as on your phone.</summary>
+          <summary>Install web apps like EtherCalc or WordPress with a click. Use our hosting, or install the platform easily on your own Linux server.</summary>
           <div><div>
             <p>Sandstorm is designed from the ground up to be radically easier to use than any other server platform.
             <p><b>Easy to get apps:</b> Installing an app on your server is like installing an app on your phone. Just choose the app you want from the app store and click "install". You never have to use command shells nor edit config files. You don't have to know about databases nor reverse proxies. Everything is done through your web browser, or handled automatically.
@@ -73,7 +73,7 @@
         <h3>Security</h3>
 
         <details>
-          <summary>Sandstorm protects you from evil (or buggy) apps while making sure security never gets in the way.</summary>
+          <summary>Sandstorm runs each app in a tight sandbox, keeping you safe from evil (or buggy) apps while making sure security never gets in the way.</summary>
           <div><div>
             <p>Sandstorm is designed by security wonks. Where most developers don't want to think about security, we care deeply about it, and have designed the whole system to protect you.
             <p><b>Protection from malware:</b> On a traditional server, installing an evil app could mean you lose everything. Under Sandstorm, each app runs in its own secure "sandbox" which starts out isolated from the world. It can't interfere with your other apps nor "phone home" to its developer until you give it permission.
@@ -88,7 +88,7 @@
         <h3>Freedom</h3>
 
         <details>
-          <summary>Don't get locked into walled gardens. Run any app you want -- even upload your own. You call the shots.</summary>
+          <summary>Sandstorm is free, open source software. Run any app you want -- even upload your own. Don't get locked into walled gardens.</summary>
           <div><div>
             <p>By separating app developers from hosts, Sandstorm leaves you in control.
             <p><b>Freedom to Choose:</b> Run any app you want. You are not limited to what's in the app store. Any developer can build a Sandstorm package, and you can upload any package to your server. You can even run Open Source and Indie apps from developers who don't have the funding to run their own servers.


### PR DESCRIPTION
This commit is intended to address the following concerns I've
heard:

* One person asked me, "How is Sandstorm different from just running
  a regular Debian server?"

* One person asked me for the "shape" of Sandstorm -- is it the kind of
  thing you install on a server? etc.

* Another person asked me for what an example of a "web app" that
  Sandstorm can run.

* This is my own concern: It isn't clear from the front page of the
  site, above the fold, that Sandstorm is open source.

This addresses those questions by adding slightly more text, and doing
some rewording, in the summary boxes.