### PR TITLE
Upgrade LibreBoard to v0.8.0

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -337,14 +337,14 @@
       </div>
 
       <div class="app">
-        <button onclick="install('118d77fa72eba6a685cb493bffb18fae?url=https://github.com/libreboard/libreboard/releases/download/v0.7.1/libreboard.spk')">Install »</button>
+        <button onclick="install('42ad4ec45ebde4f5719b988223e072c3?url=http://git.libreboard.com/libreboard/releases/blob/master/0.8.0/libreboard.spk')">Install »</button>
         <h3>LibreBoard</h3>
         <div class="app-details">
           Developed by: <a href="https://github.com/yasaricli">Yaşar İçli</a> &amp; <span class="nobr"><a href="https://github.com/mquandalle">Maxime Quandalle</a></span><br>
-          Version: 0.7.1<br>
+          Version: 0.8.0<br>
           License: MIT<br>
-          Code: <a href="https://github.com/libreboard/libreboard">On GitHub</a><br>
-          Updated: Jan 11 2015
+          Code: <a href="http://git.libreboard.com/libreboard/libreboard">On git.libreboard.com</a><br>
+          Updated: Jan 24 2015
         </div>
         <p>A “kanban” board similar to Trello that let you organize things in cards, and cards in
         lists. It supports most features you can expect (labels, comments, markdown formatting...)


### PR DESCRIPTION
We temporary moved the git repository from github to a self-hosted gitlab instance, while we work on a new UI for the next release.
Grain update was tested and is working as expected (we have some data migrations).

Note that this PR should be merged quickly because we're about to delete the previous sandstorm package hosted on github.