### PR TITLE
GitWeb version 1

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -356,13 +356,14 @@
       </div>
 
       <div class="app">
-        <button data-app-id="6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash" data-package-id="79bf8d12b973ac85e3b9409db44b00a2" data-package-url="http://sandstorm.io/apps/david/gitweb.spk">Install »</button>
+        <button data-app-id="6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash" data-package-id="6a47cde8721039a4f4e5092b41363a76" data-package-url="http://sandstorm.io/apps/david/gitweb1.spk">Install »</button>
         <h3>GitWeb</h3>
         <div class="app-details">
           Originally by: <a href="https://github.com/kaysievers">Kay Sievers</a><br>
           Ported by: <a href="https://github.com/dwrensha/">David Renshaw</a><br>
           License: GNU GPL<br>
-          Code: <a href="https://github.com/dwrensha/gitweb-sandstorm">On Github</a>
+          Code: <a href="https://github.com/dwrensha/gitweb-sandstorm">On Github</a><br>
+          Updated: Feb 3 2015
         </div>
 
         <p>A simple wrapper around <a href="http://git-scm.com/docs/gitweb">GitWeb</a> and


### PR DESCRIPTION
Uses the `Content-Encoding` header fix from https://github.com/sandstorm-io/sandstorm/pull/229.