### PR TITLE
Miscellaneous fixes

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -141,7 +141,7 @@
         <button data-app-id="nfqhx83vvzm80edpgkpax8mhqp176qj2vwg67rgq5e3kjc5r4cyh" data-package-id="5704644ebff9cc50833c77a33cab1b73" data-package-url="https://www.jgraph.com/sandstorm/package.spk">Install »</button>
         <h3>draw.io</h3>
         <div class="app-details">
-          Maintained by: <a href="https://www.jgraph.com">JGraph</a><br>
+          Developed by: <a href="https://www.jgraph.com">JGraph</a><br>
           License: Proprietary (no cost)<br>
           Updated: Feb 02 2015
         </div>
@@ -405,6 +405,7 @@
         <p><img src="gitweb.png">
       </div>
 
+      <div class="app">
         <button data-app-id="y88wavuqwz0p3tjcqtdt8egauq9hpnzr1s9efq1d63rwtj1w0ech" data-package-id="73a24c1081699b11b64c2b7397dc0719" data-package-url="http://sandstorm.io/apps/jparyani/mediawiki-1.spk">Install »</button>
         <h3>MediaWiki</h3>
         <div class="app-details">


### PR DESCRIPTION
MediaWiki app was missing the start of it's `<div>`.
JGraph is draw.io's developer, not a maintainer.