### PR TITLE
Add refreshed Meteor Todos port

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -525,14 +525,14 @@
       </div>
 
       <div class="app">
-        <button data-app-id="0dp7n6ehj8r5ttfc0fj0au6gxkuy1nhw2kx70wussfa1mqj8tf80" data-package-id="3bc25fe127f0e55d87a4514f9a4e7b40928314910db2aa21b4d286b55c26af38" data-package-url="http://sandstorm.io/apps/asheesh/meteor-todos_1.0.3.1-asheesh1.spk">Install »</button>
+        <button data-app-id="0dp7n6ehj8r5ttfc0fj0au6gxkuy1nhw2kx70wussfa1mqj8tf80" data-package-id="a8e48d94863209905887c277ae95ec4c79fe4bbe12e3b94b5bbabf90fbd425b6" data-package-url="http://sandstorm.io/apps/asheesh/meteor-todos_1.0.3.1-asheesh2.spk">Install »</button>
         <h3>Meteor Todo List</h3>
         <div class="app-details">
           Originally by: <a href="https://meteor.com">Meteor Team</a><br>
           Ported by: <a href="https://github.com/paulproteus">Asheesh Laroia</a><br>
           License: MIT<br>
           Code: <a href="https://github.com/paulproteus/meteor-todos-sandstorm">On GitHub</a><br>
-          Updated: Feb 4 2015
+          Updated: Feb 10 2015
         </div>
         <p>This is the "Todo List" example application that comes with the
         <a href="http://meteor.com">Meteor</a> development tools. The only changes

--- a/apps/index.html
+++ b/apps/index.html
@@ -525,15 +525,18 @@
       </div>
 
       <div class="app">
-        <button data-app-id="z3g0z924ea8j35mr918r2sw6t1r4xyd64490d8teweakk5v71vp0" data-package-id="5151531c1748e612ec0e4fddc71190ed" data-package-url="http://sandstorm.io/apps/meteor-todos.spk">Install »</button>
+        <button data-app-id="0dp7n6ehj8r5ttfc0fj0au6gxkuy1nhw2kx70wussfa1mqj8tf80" data-package-id="3bc25fe127f0e55d87a4514f9a4e7b40928314910db2aa21b4d286b55c26af38" data-package-url="http://sandstorm.io/apps/asheesh/meteor-todos_1.0.3.1-asheesh1.spk">Install »</button>
         <h3>Meteor Todo List</h3>
         <div class="app-details">
           Originally by: <a href="https://meteor.com">Meteor Team</a><br>
-          Ported by: <a href="https://github.com/kentonv">Kenton Varda</a><br>
-          License: MIT
+          Ported by: <a href="https://github.com/paulproteus">Asheesh Laroia</a><br>
+          License: MIT<br>
+          Code: <a href="https://github.com/paulproteus/meteor-todos-sandstorm">On GitHub</a><br>
+          Updated: Feb 4 2015
         </div>
         <p>This is the "Todo List" example application that comes with the
-        <a href="http://meteor.com">Meteor</a> development tools. No code changes were necessary.
+        <a href="http://meteor.com">Meteor</a> development tools. The only changes
+        were to remove some user interface elements for login.</a></p>
       </div>
 
       <div class="app">


### PR DESCRIPTION
Notable things about this changeset:

* It uses Debian-style package filenames -- specifically, this came
  from Meteor 1.0.3.1, and this is the first release by me.

* It has a new app ID. There have been a large number of
  backwards-incompatible changes between the previous Meteor todo demo
  app and this one, and @kentonv and I decided that it was better if
  we avoided stomping on people's data, and it didn't seem necessary
  to migrate it since this is just a toy app.