### PR TITLE
Add dependency on separate logos/ repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "logos"]
+	path = logos
+	url = https://github.com/sandstorm-io/logos.git


### PR DESCRIPTION
The logos/ repo contains the image assets we want others to use.

Right now, it only contains the buttons required for a "Try it now!"
button for Sandstorm apps. In the future, I would like it to include the
current Sandstorm logo in high- quality formats, and any other image
files we want people to use when referring to Sandstorm.

I think it makes sense for logos to be a separate repo because the files
in there are expected to have long-lasting names. By contrast, I think
we currently feel pretty free to remove files from this website
repository and/or remove files from it. Also, I really want one repo I
can point people to and say, "If you want files to use in presentations
to to copy onto your website, here is the list of them."

This will let people use https://sandstorm.io/logos/* to map to files in
the logos/ repository. I plan to also use these URLs in an upcoming blog
post.