### PR TITLE
GitWeb v0.0.3

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -485,14 +485,14 @@
       </div>
 
       <div class="app">
-        <button data-app-id="6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash" data-package-id="6a47cde8721039a4f4e5092b41363a76" data-package-url="http://sandstorm.io/apps/david/gitweb1.spk">Install »</button>
+        <button data-app-id="6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash" data-package-id="15e88304b6d4f3a127a0e1f60cf41588" data-package-url="http://sandstorm.io/apps/david/gitweb3.spk">Install »</button>
         <h3>GitWeb</h3>
         <div class="app-details">
           Originally by: <a href="https://github.com/kaysievers">Kay Sievers</a><br>
           Ported by: <a href="https://github.com/dwrensha/">David Renshaw</a><br>
           License: GNU GPL<br>
           Code: <a href="https://github.com/dwrensha/gitweb-sandstorm">On Github</a><br>
-          Updated: Feb 3 2015
+          Updated: April 24 2015
         </div>
 
         <p>A simple wrapper around <a href="http://git-scm.com/docs/gitweb">GitWeb</a> and


### PR DESCRIPTION
Includes "developer" and "guest" roles. The "developer" role is default, as it corresponds to the permissions that sharing-by-URL used to grant.