### PR TITLE
Link to Acronymy instance from a domain I control.

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -608,7 +608,7 @@
           as an acronym of other words. The app is notable in that it is written in
           <a href="http://www.rust-lang.org/">Rust</a> directly against the low-level Sandstorm API,
           thus avoiding the need for an HTTP server.
-        <p>Also try <a href="https://alpha.sandstorm.io/grain/Evmjn3tJbDCJjT4Be">David's shared instance</a>.
+        <p>Also try <a href="https://dwrensha.ws/acronymy">David's shared instance</a>.
       </div>
 
       <div class="app">


### PR DESCRIPTION
I'll want to upgrade the shared Acronymy instance to the new sharing model at some point. That'll be easiest if I just have to edit the redirect I've set up at https://dwrensha.ws/acronymy .