### PR TITLE
Create version 1 of install page

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -27,7 +27,7 @@
 
     <main>
       <p id="title">
-        <b>Sandstorm is <span id="js-replace">open source</a></b>
+        <b>Sandstorm is <span id="js-replace-appname">open source</a></b>
         and runs on recent Linux distributions.
       </p>
       <p class="textbody">

--- a/install/index.html
+++ b/install/index.html
@@ -31,7 +31,10 @@
         and runs on recent Linux distributions.
       </p>
       <p class="textbody">
-        If you don't know Sandstorm yet, try the <a href="https://demo.sandstorm.io/">demo</a>!
+        If you don't know Sandstorm
+        yet, it lets you install server apps as easily as you install apps on your phone. <span id="js-replace-check-out">Try
+          the</span> <a id="js-replace-homepage-url" href="https://demo.sandstorm.io/">
+          <span id="js-replace-website">90 second demo</span></a>!
       </p>
 
       <div id="note">
@@ -65,7 +68,7 @@
       <hr>
       <p class="textbody">Once you've logged in, click the <em>Install apps</em> button.</p>
 
-      <p class="secondary textbody">You can now run apps like EtherCalc, GitLab, LibreBoard, Wave, and more as easily as you'd install apps on your phone.</p>
+      <p class="secondary textbody">Apps in Sandstorm run with a click. You won't need to edit server configuration files or provision databases. Sandstorm manages access control, so apps are private by default.</p>
 
       <!-- When Sandcats is announced, add a remark here. -->
 

--- a/install/index.html
+++ b/install/index.html
@@ -51,7 +51,7 @@
 
       <p class="subtitle">1. Download & run the installer</p>
       <hr>
-      <p class="textbody">Run this in a terminal. <a href="https://asciinema.org/a/8ph10y0ie9xumvgmlibu4g8k8?autoplay=1">(Or watch a 30 second screencast.)</a></p>
+      <p class="textbody">Run this in a terminal. <a href="https://asciinema.org/a/bw9mgfk8m55rfa3ntrfvhvjat?autoplay=1">(Or watch a 30 second screencast.)</a></p>
       <p class="textbody"><pre>curl https://install.sandstorm.io | bash</pre></p>
       <p class="textbody">
 

--- a/install/index.html
+++ b/install/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>Install Sandstorm</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="/install/install.css">
+  </head>
+
+  <body>
+    <nav>
+      <a href="/">Sandstorm.io</a>
+      <a class="md" href="https://demo.sandstorm.io">Demo</a>
+      <a class="md" href="https://blog.sandstorm.io">News</a>
+      <a class="md" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
+      <a class="md" href="https://github.com/sandstorm-io/sandstorm/wiki/Get-Involved">Get Involved</a>
+      <a class="lg" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
+    </nav>
+
+    <header>
+      <div>
+        <h3>Sandstorm.io</h3>
+        <h4>INSTALL INSTRUCTIONS</h4>
+      </div>
+    </header>
+
+    <main>
+      <p id="title">
+        <b>Sandstorm is <span id="js-replace">open source</a></b>
+        and runs on recent Linux distributions.
+      </p>
+      <p class="textbody">
+        If you don't know Sandstorm yet, try the <a href="https://demo.sandstorm.io/">demo</a>!
+      </p>
+
+      <div id="note">
+        <p>
+          To run Sandstorm, you need a Linux server connected to the Internet.
+        </p>
+
+        <p>
+          If you don't already have somewhere to run Sandstorm,
+          consider creating an Ubuntu 14.04 virtual machine
+          on your favorite cloud provider.
+        </p>
+      </div>
+
+      <p class="subtitle">1. Download & run the installer</p>
+      <hr>
+      <p class="textbody">Run this in a terminal. <a href="https://asciinema.org/a/8ph10y0ie9xumvgmlibu4g8k8?autoplay=1">(Or watch a 30 second screencast.)</a></p>
+      <p class="textbody"><pre>curl https://install.sandstorm.io | bash</pre></p>
+      <p class="textbody">
+
+      <p class="subtitle">2. Configure login</p>
+      <hr>
+      <p class="textbody">The install script prints the URL of your
+      server's admin panel. Follow that link.</p>
+      <p class="textbody">Your first action with Sandstorm is to use
+        the <em>admin panel</em> to choose Google login,
+        GitHub login, or email login.
+      </p>
+
+      <p class="subtitle">3. Install apps</p>
+      <hr>
+      <p class="textbody">Once you've logged in, click the <em>Install apps</em> button.</p>
+
+      <p class="textbody">You can now run apps like EtherCalc, GitLab, LibreBoard, Wave, and more as easily as you'd install apps on your phone.</p>
+
+      <!-- When Sandcats is announced, add a remark here. -->
+
+      <p class="subtitle">4. Stay in touch</p>
+      <hr>
+      <p class="textbody">Read about how
+      to <a href="https://github.com/sandstorm-io/sandstorm/wiki/Get-Involved">get
+      involved</a> in the project and become a part of the
+      community.</p>
+</main>
+
+    <!-- Google Analytics -->
+    <script type="text/javascript">
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-42127409-1', 'sandstorm.io');
+      ga('send', 'pageview');
+    </script>
+
+    <!-- JS to rewrite the page header in case we came from appDemo. -->
+    <script src="install.js"></script>
+  </body>
+</html>

--- a/install/index.html
+++ b/install/index.html
@@ -65,7 +65,7 @@
       <hr>
       <p class="textbody">Once you've logged in, click the <em>Install apps</em> button.</p>
 
-      <p class="textbody">You can now run apps like EtherCalc, GitLab, LibreBoard, Wave, and more as easily as you'd install apps on your phone.</p>
+      <p class="secondary textbody">You can now run apps like EtherCalc, GitLab, LibreBoard, Wave, and more as easily as you'd install apps on your phone.</p>
 
       <!-- When Sandcats is announced, add a remark here. -->
 

--- a/install/install.css
+++ b/install/install.css
@@ -180,6 +180,10 @@ p.textbody {
   margin-right: auto;
 }
 
+p.secondary {
+  color: #9c83aa;
+}
+
 p > a {
   color: #943E9B;
   font-weight: bold;

--- a/install/install.css
+++ b/install/install.css
@@ -1,0 +1,215 @@
+/* Responsive classes to throw away some navigation as needed. */
+@media only screen and (max-width: 768px) {
+  .md {
+    display: none;
+  }
+}
+@media only screen and (max-width: 992px) {
+  .lg {
+    display: none;
+  }
+}
+
+@font-face {
+  font-family: "Open Sans";
+  font-style: normal;
+  font-weight: normal;
+  src: local("Open Sans Light"), local("OpenSans-Light"),
+      url(/fonts/opensans-light.woff) format('woff'),
+      url(/fonts/opensans-light.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: "Open Sans";
+  font-style: normal;
+  font-weight: bold;
+  src: local("Open Sans Semibold"), local("OpenSans-Semibold"),
+      url(/fonts/opensans-semibold.woff) format('woff'),
+      url(/fonts/opensans-semibold.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: "Open Sans";
+  font-style: italic;
+  font-weight: normal;
+  src: local("Open Sans Light Italic"), local("OpenSans-LightItalic"),
+      url(/fonts/opensans-lightitalic.woff) format('woff'),
+      url(/fonts/opensans-lightitalic.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: "Open Sans";
+  font-style: italic;
+  font-weight: bold;
+  src: local("Open Sans Semibold Italic"), local("OpenSans-SemiboldItalic"),
+      url(/fonts/opensans-semibolditalic.woff) format('woff'),
+      url(/fonts/opensans-semibolditalic.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: "Source Sans";
+  font-style: normal;
+  font-weight: normal;
+  src: local("Source Sans Light"), local("SourceSans-Light"),
+      url(/fonts/sourcesans-light.woff) format('woff'),
+      url(/fonts/sourcesans-light.ttf) format('truetype');
+}
+
+@font-face {
+  font-family: "Source Sans";
+  font-style: normal;
+  font-weight: bold;
+  src: local("Source Sans"), local("SourceSans"),
+      url(/fonts/sourcesans-regular.woff) format('woff'),
+      url(/fonts/sourcesans-regular.ttf) format('truetype');
+}
+
+nav {
+  font-family: "Open Sans", sans-serif;
+  background-image: url(/images/logo.svg);
+  background-repeat: no-repeat;
+  background-size: 160px 35px;
+  height: 44px;
+  color: #460e54;
+  line-height: 44px;
+  text-align: right;
+  font-size: 14pt;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+nav::after {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 44px;
+  z-index: -1;
+  background-color: #fffbfb;
+}
+
+nav>a {
+  display: inline-block;
+  padding: 0 32px;
+  text-decoration: none;
+  color: #460e54;
+}
+
+nav>a:first-of-type {
+  padding-left: 50px;
+  float: left;
+  margin: 0;
+}
+
+header {
+  width: 100%;
+  display: table;
+  min-height: 200px;
+  background-color: #783189;
+  background: linear-gradient(#281E43, #8964A7);
+  margin: 0px;
+}
+
+/* hackery to vertically align the contents like a table */
+header>div {
+  font-family: "Open Sans", sans-serif;
+  display: table-cell;
+  margin: auto;
+  text-align: center;
+  vertical-align: middle;
+  color: white;
+}
+
+header>div>h3 {
+  font-size: 48px;
+  margin-bottom: 0px;
+}
+
+header>div>h3::before {
+  content: " ";
+  display: inline-block;
+  background-image: url(/images/logo-white.svg);
+  background-repeat: no-repeat;
+  width: 90px;
+  height: 90px;
+  margin-right: -20px;
+}
+
+header>div>h4 {
+  color: #FFD4EC;
+  font-weight: 300;
+  margin-top: 0.25em;
+  font-size: 28px;
+}
+
+body {
+  font-family: "Source Sans", sans-serif;
+  font-size: 21px;
+  text-align: center;
+  margin: 0px;
+}
+
+p {
+  color: #6A237C;
+  margin: 0px;
+}
+
+hr {
+  max-width: 400px;
+  border: 0px;
+  border-bottom: solid 1px #EDB2DB;
+}
+
+p#title {
+  padding-left: 1em;
+  padding-right: 1em;
+  margin-top: 2em;
+  font-size: 34px;
+}
+
+p.textbody {
+  padding-right: 1em;
+  padding-left: 1em;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  line-height: 150%;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+p > a {
+  color: #943E9B;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+div#note {
+  margin-top: 1em;
+  width: 100%;
+  text-align: center;
+  background-color: #FDE5EF;
+  color: #783189;
+}
+
+div#note > p {
+    max-width: 500px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+div#note > p+p {
+  margin-top: 1em;
+}
+
+p.subtitle {
+  margin-top: 3em;
+  font-size: 22px;
+}
+
+pre {
+  margin-left: 1em;
+  margin-right: 1em;
+}

--- a/install/install.css
+++ b/install/install.css
@@ -210,7 +210,7 @@ div#note > p+p {
 
 p.subtitle {
   margin-top: 3em;
-  font-size: 22px;
+  font-size: 25px;
 }
 
 pre {

--- a/install/install.css
+++ b/install/install.css
@@ -191,11 +191,13 @@ p > a {
 }
 
 div#note {
+  padding-top: 10px;
   margin-top: 1em;
   width: 100%;
   text-align: center;
   background-color: #FDE5EF;
   color: #783189;
+  padding-bottom: 10px;
 }
 
 div#note > p {

--- a/install/install.js
+++ b/install/install.js
@@ -1,0 +1,9 @@
+function updatePageTitle() {
+  var hash = window.location.hash.replace("#", "");
+  if (hash) {
+    var span = document.getElementById("js-replace");
+    span.textContent = "the easiest way to run " + hash;
+  }
+}
+
+updatePageTitle();

--- a/install/install.js
+++ b/install/install.js
@@ -1,9 +1,37 @@
-function updatePageTitle() {
+function updateHeading() {
+  // The hash contains any of:
+  //
+  // - Nothing, in which case, we do nothing.
+  //
+  // - The literal string "demo", in which case we know the user came
+  //   from the demo, but we don't know what app they were using.
+  //
+  // - The name of the app they were using, in which case we also know
+  //   that they are coming from the demo.
+
   var hash = window.location.hash.replace("#", "");
   if (hash) {
-    var span = document.getElementById("js-replace-appname");
-    span.textContent = "the easiest way to run " + hash;
+    // If there is a hash at all, it means they came from the demo. So
+    // there's no point linking the user to the demo.
+    var span;
+    var a;
+
+    span = document.getElementById('js-replace-check-out');
+    span.textContent = "Check out";
+
+    span = document.getElementById('js-replace-website');
+    span.textContent = "the project website";
+
+    a = document.getElementById('js-replace-homepage-url');
+    a.href = 'https://sandstorm.io/';
+
+    if (hash != "demo") {
+      // Then update the app name, too.
+      span = document.getElementById("js-replace-appname");
+      span.textContent = "the easiest way to run " + hash;
+    }
+
   }
 }
 
-updatePageTitle();
+updateHeading();

--- a/install/install.js
+++ b/install/install.js
@@ -1,7 +1,7 @@
 function updatePageTitle() {
   var hash = window.location.hash.replace("#", "");
   if (hash) {
-    var span = document.getElementById("js-replace");
+    var span = document.getElementById("js-replace-appname");
     span.textContent = "the easiest way to run " + hash;
   }
 }


### PR DESCRIPTION
**Goal**

This pull request creates an `/install/` page, so that when people know they need to install Sandstorm, they can go to a page that is more inviting than github.com/sandstorm-io/sandstorm.

I worked with @neynah on the colors and spacing.

I'm interested in this primarily so that users of `demo.sandstorm.io` can see a button at the top that links to this page. See https://github.com/sandstorm-io/sandstorm/pull/408 for the Sandstorm shell side of things.

**Status**

Ready for review/merge.

This pull request must go live before https://github.com/sandstorm-io/sandstorm/pull/408 .

**Technical details**

Features:

* If you visit this page with #EtherCalc   tells you Sandstorm
  is the easiest way to run EtherCalc. The purpose of this
  is to integrate with a link at the top of the demo.

* Explains how to install Sandstorm, with design modeled after the
  pre-order page.

* Is responsive.