### PR TITLE
Record full URL in analytics, including hash

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -89,8 +89,7 @@
 
       // Do normal Google Analytics stuff.
       ga('create', 'UA-42127409-1', 'sandstorm.io');
-      ga('send', 'pageview');
-      // Also send a pageview event that indicates the window.location.hash, so we
+      // Send a pageview event that indicates the window.location.hash, so we
       // have a sense of which apps' install links are popular.
       var fullUrl = (window.location.protocol + '//' + window.location.hostname +
                      window.location.pathname + window.location.hash);

--- a/install/index.html
+++ b/install/index.html
@@ -87,8 +87,14 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+      // Do normal Google Analytics stuff.
       ga('create', 'UA-42127409-1', 'sandstorm.io');
       ga('send', 'pageview');
+      // Also send a pageview event that indicates the window.location.hash, so we
+      // have a sense of which apps' install links are popular.
+      var fullUrl = (window.location.protocol + '//' + window.location.hostname +
+                     window.location.pathname + window.location.hash);
+      ga('send', 'pageview', fullUrl);
     </script>
 
     <!-- JS to rewrite the page header in case we came from appDemo. -->


### PR DESCRIPTION
This is necessary so we can get a sense of _which_ install pages
are being seen by visitors to the site.

Testing done:

* Manually test that `fullUrl` is the full URL, including the hash, by temporarily adding an `alert(fullUrl);` line. (I've removed that line before submitting this pull request.)