### PR TITLE
Make "Run your own" link point to the /install/ page

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       </div>
       <div class="action-or">or</div>
       <div class="action-button">
-        <a class="button" href="https://github.com/sandstorm-io/sandstorm">Run your own »</a>
+        <a class="button" href="https://sandstorm.io/install/">Run your own »</a>
         Self-host on Linux
       </div>
 


### PR DESCRIPTION
Linking straight to Github is less helpful than our own page that is meant to
guide people through the install process.