### PR TITLE
Use just path + hash for Google Analytics

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -91,8 +91,7 @@
       ga('create', 'UA-42127409-1', 'sandstorm.io');
       // Send a pageview event that indicates the window.location.hash, so we
       // have a sense of which apps' install links are popular.
-      var fullUrl = (window.location.protocol + '//' + window.location.hostname +
-                     window.location.pathname + window.location.hash);
+      var fullUrl = (window.location.pathname + window.location.hash);
       ga('send', 'pageview', fullUrl);
     </script>
 


### PR DESCRIPTION
Per https://developers.google.com/analytics/devguides/collection/analyticsjs/pages ,
the "pageview" event needs only the path; it figures out the domain and
protocol by itself.

Therefore, we are cluttering up GA with bad data at the moment until we deploy
this.

Requesting @kentonv 's review + merge.