### PR TITLE
Update link to packaging guide.

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -692,8 +692,8 @@
         <h3>Your App Here</h3>
         <p>Have you written a Sandstorm app that you'd like to see here?
           <a href="https://groups.google.com/group/sandstorm-dev">Let us know.</a>
-        <p>Have an app you want to port to Sandstorm? Check out the
-          <a href="https://github.com/sandstorm-io/sandstorm/wiki/Porting-Guide">porting guide</a>!
+        <p>Have an app you want to package for Sandstorm? Check out the
+          <a href="https://docs.sandstorm.io/en/latest/developing/raw-packaging-guide/">packaging guide</a>!
       </div>
     </div>
 


### PR DESCRIPTION
The 'porting guide' link was outdated. It pointed through two manual redirects to the packaging guide.
This changes it to point directly to the guide.