### PR TITLE
Gitweb version 5.

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -506,14 +506,14 @@
       </div>
 
       <div class="app">
-        <button data-app-id="6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash" data-package-id="c8aefd836d257721d3cd96d9d8209b59" data-package-url="http://sandstorm.io/apps/david/gitweb4.spk">Install »</button>
+        <button data-app-id="6va4cjamc21j0znf5h5rrgnv0rpyvh1vaxurkrgknefvj0x63ash" data-package-id="26eb486a44085512a678c543fc7c1fdd" data-package-url="http://sandstorm.io/apps/david/gitweb5.spk">Install »</button>
         <h3>GitWeb</h3>
         <div class="app-details">
           Originally by: <a href="https://github.com/kaysievers">Kay Sievers</a><br>
           Ported by: <a href="https://github.com/dwrensha/">David Renshaw</a><br>
           License: GNU GPL<br>
           Code: <a href="https://github.com/dwrensha/gitweb-sandstorm">On Github</a><br>
-          Updated: July 12 2015
+          Updated: August 2 2015
         </div>
 
         <p>A simple wrapper around <a href="http://git-scm.com/docs/gitweb">GitWeb</a> and


### PR DESCRIPTION
The copy/paste offer template instructions now automatically configure the "store" credential helper.

This depends on https://github.com/sandstorm-io/sandstorm/pull/633, so should not be merged until that fix makes it onto the Alpha and Oasis servers.