### PR TITLE
Update link for Game of Y.

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -577,7 +577,7 @@
           Originally by: <a href="http://y.hyperbotics.org/">Hyperbotics</a><br>
           Ported by: <a href="https://github.com/kentonv/">Kenton Varda</a><br>
           License: GNU AGPL<br>
-          Code: <a href="https://github.com/hyperbotics/y">On GitHub</a><br> (Ported using
+          Code: <a href="https://github.com/harshavardhana/y">On GitHub</a><br> (Ported using
           <a href="https://github.com/sandstorm-io/meteor-spk">meteor-spk</a> with no code changes)
         </div>
         <p>A port of <a href="http://y.hyperbotics.org/">Hyperbotics'</a> implementation of


### PR DESCRIPTION
http://y.hyperbotics.org/ now points to https://github.com/harshavardhana/y, and https://github.com/hyperbotics/y is gone.