### PR TITLE
Link to docs from front page & install page. Use install page more consistently.

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
             <p><b>Protection from bugs:</b> Let's face it: most developers don't think enough about security, and they end up producing apps that have bugs allowing hackers to get in. Sandstorm automatically protects apps against a wide range of common vulnerabilities, and security-critical functions like login and sharing are handled by the system itself.
             <p><b>Protection from spying:</b> Sandstorm apps cannot phone home, so they cannot collect data about you for advertising purposes nor perform unwanted experiments on you. Moreover, we are developing advanced per-document encryption techniques to thwart even dedicated hackers.
             <p><b>No protection from getting your job done:</b> Security can often be a hassle, getting in the way of your work. Sandstorm is different. When you tell a Sandstorm app to talk to some other app, or to talk to the internet, Sandstorm sees your intent and automatically grants it access. So, you are never interrupted by a prompt asking "Do you want to allow this app to the thing you just told it to do?" And yet, the apps only get the permissions you actually wanted them to have.
-            <p><a href="https://github.com/sandstorm-io/sandstorm/wiki/Security-Practices-Overview">Learn how Sandstorm's security works »</a>
+            <p><a href="https://docs.sandstorm.io/en/latest/developing/security-practices/">Learn how Sandstorm's security works »</a>
           </div></div>
         </details>
       </section>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
               <li><h4>Protect your privacy</h4><p>Sandstorm apps can only talk to the outside world with your explicit permission.  That means they can't secretly <a href="http://news.cnet.com/8301-10805_3-57620658-75/microsoft-sniffed-bloggers-hotmail-account-to-trace-leak/">spy</a> on you, develop an <a href="https://www.google.com/settings/ads">advertising profile</a> from your data, or <a href="http://www.nytimes.com/2014/06/30/technology/facebook-tinkers-with-users-emotions-in-news-feed-experiment-stirring-outcry.html?_r=0">perform psych experiments</a> on you without your consent. Plus, apps running on your server do not <a href="http://reader.google.com">disappear</a> when the developer stops supporting them.
               <li><h4>Don't get locked in</h4><p>When developers run the servers, they can lock you in to their walled garden, refusing to play nice with competitors they don't like. Sandstorm puts all your apps and data under <i>your</i> roof, where you can mix and match apps as you please. You can even freely move between hosts and take all your apps and data with you.
             </ul>
-            <p style="text-align: center"><a class="button" href="preorder.html">Pre-order hosting »</a> <a class="button" href="https://github.com/sandstorm-io/sandstorm">Run your own »</a></p>
+            <p style="text-align: center"><a class="button" href="preorder.html">Pre-order hosting »</a> <a class="button" href="/install/">Run your own »</a></p>
           </div></div>
         </details>
       </section>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
       <a href="https://blog.sandstorm.io">News</a>
       <a href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
       <a href="https://github.com/sandstorm-io/sandstorm/wiki/Get-Involved">Get Involved</a>
+      <a href="https://docs.sandstorm.io/">Docs</a>
       <a href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
     </nav>
 
@@ -945,6 +946,7 @@
         <li><a href="https://demo.sandstorm.io">Demo</a>
         <li><a href="https://blog.sandstorm.io">News</a>
         <li><a href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
+        <li><a href="https://docs.sandstorm.io/">Docs</a>
         <li><a href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
       </ul>
       <p>This page was hand-crafted using only the finest web technologies.

--- a/install/index.html
+++ b/install/index.html
@@ -90,7 +90,13 @@
       to <a href="https://github.com/sandstorm-io/sandstorm/wiki/Get-Involved">get
       involved</a> in the project and become a part of the
       community.</p>
-</main>
+
+      <p class="textbody">For troubleshooting tips and next steps,
+        <a href="https://docs.sandstorm.io/en/latest/administering/">
+          read the documentation.</a>
+      </p>
+
+    </main>
 
     <!-- Google Analytics -->
     <script type="text/javascript">

--- a/style.css
+++ b/style.css
@@ -993,7 +993,7 @@ footer>ul {
 footer>ul>li {
   list-style-type: none;
   display: inline-block;
-  margin: 1em 60px;
+  margin: 1em 50px;
 }
 
 footer>ul>li>a {


### PR DESCRIPTION
See commit log messages for these 4 commits for details.

Props to @xcombelle for noticing that the main site needs proper links to the docs.