### PR TITLE
Mobile padding tweaks

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -340,7 +340,7 @@ body >footer {
 
 .action {
   text-align: center;
-  padding: 35px 0;
+  padding: 30px 0;
 
   @include stripe {
     background-color: #F4F3FB;
@@ -353,7 +353,8 @@ body >footer {
       
       @media (max-width: 800px) {
         display: block;
-        padding-bottom: 25px;
+        line-height: 30px;
+        padding: 10px 0;
       }
     }
 
@@ -369,6 +370,13 @@ body >footer {
         color: #7356cc;
       }
       white-space: nowrap;
+      
+      @media (max-width: 800px) {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+        line-height: 40px;
+      }
     }
 }
 
@@ -1495,7 +1503,7 @@ body >footer {
         }
 
         &.plan2 {
-          margin: 0 2% 0 2%;
+          margin: 0 2% 20px 2%;
           width: 45%;
           position: relative;
           box-shadow: 0 1px 3px rgba(0,0,0,0.2);


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/855341/12312899/0cf12564-ba18-11e5-80e6-62a4410b4a32.png)



Also added padding below self-host plans so that they don't look attached to each other when they're stacked.