### PR TITLE
Font weight adjustment on /get

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -1356,6 +1356,11 @@ body >footer {
 
     p { margin-bottom: 0; }
   }
+  
+  section h2 {
+    padding-top: 20px;
+    font-weight: 300;
+  }
 
   #where {
     display: flex;


### PR DESCRIPTION
Small adjustment based on user testing results. User was initially confused and thought there were 3 options: Managed Hosting, Sandstorm Oasis, and Self-host.

We may also want to consider changing "Sandstorm Oasis: Hosting by Sandstorm.io" to something like "Hosting by Sandstorm.io on Oasis" so it looks even less like a 3rd option?

![image](https://cloud.githubusercontent.com/assets/855341/12313298/2a58bcd6-ba1b-11e5-951a-51fe6e09b53e.png)
