### PR TITLE
Switch to bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+gem 'jekyll'
+gem 'guard'
+gem 'guard-jekyll-plus'
+gem 'guard-livereload'
+gem 'octopress-autoprefixer'
+gem 'jekyll-paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,93 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    autoprefixer-rails (6.3.1)
+      execjs
+      json
+    coderay (1.1.0)
+    colorator (0.1)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.0.9.1)
+    execjs (2.6.0)
+    ffi (1.9.10)
+    formatador (0.2.5)
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-jekyll-plus (2.0.2)
+      guard (~> 2.10, >= 2.10.3)
+      guard-compat (~> 1.1)
+      jekyll (>= 1.0.0)
+    guard-livereload (2.5.1)
+      em-websocket (~> 0.5)
+      guard (~> 2.8)
+      guard-compat (~> 1.0)
+      multi_json (~> 1.8)
+    http_parser.rb (0.6.0)
+    jekyll (3.0.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-watch (1.3.1)
+      listen (~> 3.0)
+    json (1.8.3)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    lumberjack (1.0.10)
+    mercenary (0.3.5)
+    method_source (0.8.2)
+    multi_json (1.11.2)
+    nenv (0.2.0)
+    notiffany (0.0.8)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    octopress-autoprefixer (2.0.0)
+      autoprefixer-rails
+      jekyll (~> 3.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.21)
+    shellany (0.0.1)
+    slop (3.6.0)
+    thor (0.19.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  guard
+  guard-jekyll-plus
+  guard-livereload
+  jekyll
+  jekyll-paginate
+  octopress-autoprefixer
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -4,11 +4,15 @@ When checking out this repository, make sure to use `--recursive` to get submodu
 
     git clone --recursive git@github.com:sandstorm-io/sandstorm-website.git
 
+If you forgot to do that, you can recover with this command.
+
+    git submodule init
+    git submodule update
+
 To edit with live-reload:
 
-1. Intsall Rubygems.
-2. Install gems:
-
-       gem install jekyll guard guard-jekyll-plus guard-livereload octopress-autoprefixer jekyll-paginate
-3. Run `guard`.
+1. Install Rubygems and bundler.
+2. Install gems.
+       bundle install --path vendor/bundle
+3. Run `bundle exec guard`
 4. Open [http://localhost:4000](http://localhost:4000).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ If you forgot to do that, you can recover with this command.
 To edit with live-reload:
 
 1. Install Rubygems and bundler.
-2. Install gems.
-       bundle install --path vendor/bundle
+2. Install gems: `bundle install --path vendor/bundle`
 3. Run `bundle exec guard`
 4. Open [http://localhost:4000](http://localhost:4000).

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ exclude:
   - "sandstorm.io.*"
   - README.md
   - "*.sh"
+  - vendor
 gems:
   - octopress-autoprefixer
   - jekyll-paginate


### PR DESCRIPTION
Rationale: I really do not want to run gem install as root. This also switches
the list of gems to "executable documentation", which ensures they do not get
out of sync with reality.