### PR TITLE
Guardfile: Use all regexes, all the time

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -2,8 +2,8 @@
 # any time a source file is changed.
 
 ignore /\.autosave$/
-ignore "_pushsite"
-ignore "_published"
+ignore /_pushsite/
+ignore /_published/
 
 guard 'livereload' do
   watch(%r{^_site/})


### PR DESCRIPTION
This avoids a crash in match() in the "listen" gem.