### PR TITLE
Add pricing to Sandstorm for Work page

### DIFF
--- a/business.html
+++ b/business.html
@@ -20,6 +20,8 @@ title: "Sandstorm Business Features"
 <section id="business-scale">
   <h2>Sandstorm for Work</h2>
   <h3>Sandstorm for Work extends Sandstorm with features that businesses need.</h3>
+  <p>Priced at $15/user/month. Special pricing available for <a href="https://docs.sandstorm.io/en/latest/administering/for-work/#special-pricing">
+      non-profits.</a></p>
 <ul id="business">
     <li class="on-prem">
       <div class="row">

--- a/business.html
+++ b/business.html
@@ -20,7 +20,7 @@ title: "Sandstorm Business Features"
 <section id="business-scale">
   <h2>Sandstorm for Work</h2>
   <h3>Sandstorm for Work extends Sandstorm with features that businesses need.</h3>
-  <p>Priced at $15/user/month. Special pricing available for <a href="https://docs.sandstorm.io/en/latest/administering/for-work/#special-pricing">
+  <p>Priced at $15 per user per month. Special pricing available for <a href="https://docs.sandstorm.io/en/latest/administering/for-work/#special-pricing">
       non-profits.</a></p>
 <ul id="business">
     <li class="on-prem">

--- a/get.html
+++ b/get.html
@@ -78,7 +78,7 @@ title: Get Sandstorm
     <li class="plan2">
     <ul id="organizations">
         <li class="title"><strong>Organizations</strong><br><p><a href="/business">Sandstorm for Work</a> adds features and integrations that businesses need.</p><img src="/images/get-organizations.svg">
-			<li class="price"><strong>Custom Pricing</strong>
+			<li class="price"><strong>$15 per user per month</strong>
         <li class="storage"><strong>Storage is up to you!</strong>
         <li class="grains">Unlimited grains</li>
         <li class="get"><a href="https://docs.google.com/a/corp.sandstorm.io/forms/d/15RikXG1b-giAf93PJiCd2bkPBvGhR_MT3ocziEzbqOw/viewform">Contact Us</a></li>


### PR DESCRIPTION
This commit adds pricing to the Sandstorm for Work page. See also this docs pull request:

- https://github.com/sandstorm-io/sandstorm/pull/1659

This adds a link to the `#special-pricing` div within the docs. The purpose is to help non-profits discover that there is special pricing available in a way that helps for-profits still believe Sandstorm for Work is a worthwhile way to spend money.

Screenshot attached. I experimented with a few other places to add pricing. I think this is the most time-effective thing we can do. I think that most other places require more significant redesigns. For example, we could create a new icon box for this pricing information, but I think that draws more attention to it than needed, and would take some design work. 

![screenshot from 2016-03-18 00 55 27](https://cloud.githubusercontent.com/assets/25457/13871980/297a74ce-eca4-11e5-89f0-5c4efaaab3b4.png)