### PR TITLE
Refer to developer docs as Developer Portal

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -66,9 +66,9 @@
         <li>
           <h3><a href="https://docs.sandstorm.io">Documentation</a></h3>
           <ul>
-            <li><a href="https://docs.sandstorm.io/en/latest/using/">Using</a>
-            <li><a href="https://docs.sandstorm.io/en/latest/developing/">Developing</a>
-            <li><a href="https://docs.sandstorm.io/en/latest/administering/">Administrating</a>
+            <li><a href="https://docs.sandstorm.io/en/latest/using/">How to use Sandstorm</a>
+            <li><a href="https://docs.sandstorm.io/en/latest/developing/">Developer Portal</a>
+            <li><a href="https://docs.sandstorm.io/en/latest/administering/">Administering &amp; installing</a>
             <li><a href="https://docs.sandstorm.io/en/latest/using/security-practices/">Security</a>
           </ul>
         </li>

--- a/developer.html
+++ b/developer.html
@@ -15,7 +15,7 @@ title: "Sandstorm Developer Features"
   </div>
 </header>
 
-<span class="start"><a href="https://docs.sandstorm.io/en/latest/developing/">See Developer Documentation</a></span>
+<span class="start"><a href="https://docs.sandstorm.io/en/latest/developing/">See Developer Portal</a></span>
 
 <section id="developer">
   <h2>Developer Features</h2>
@@ -59,7 +59,7 @@ title: "Sandstorm Developer Features"
   </ul>
 
   <div class="action">
-      <li>You can package apps for the <a href="http://apps.sandstorm.io">App Market</a> today</li><a href="https://docs.sandstorm.io/en/latest/vagrant-spk/packaging-tutorial/">See Tutorial</a>
+      <li>You can package apps for the <a href="http://apps.sandstorm.io">App Market</a> today</li><a href="https://docs.sandstorm.io/en/latest/developing/">See Developer Portal</a>
   </div>
 
 </section>


### PR DESCRIPTION
Specifically:

- Rename link in footer to say "Developer Portal"

- Rename link at top of /developer to say "See Developer Portal"

- Adjust link at bottom of /developer to link to the top of the development-related docs,
  and say so by renaming the call-to-action button to say See Developer Portal

Refs #173

While at it:

- Rename other links in the footer

Note that I have not fiddled with contrast etc. If @neynah wants to do that, +1.