### PR TITLE
Feature comparison

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -42,9 +42,9 @@
         <li>
           <h3><a href="/get">Get Sandstorm</a></h3>
           <ul>
-            <li><a href="/get#managed-hosting">Hosting</a>
-            <li><a href="/get#self-host">Download</a>
-            <li><a href="/get#self-host">For Organizations</a>
+            <li><a href="/get">Sandstorm on Oasis</a>
+            <li><a href="/get">Sandstorm Standard</a>
+            <li><a href="/get">Sandstorm for Work</a>
             <li><a href="https://github.com/sandstorm-io/sandstorm">Source Code (GitHub)</a>
           </ul>
         </li>

--- a/_posts/2016-01-22-8-new-open-source-apps.md
+++ b/_posts/2016-01-22-8-new-open-source-apps.md
@@ -5,7 +5,7 @@ author: Jade Wang
 authorUrl: https://github.com/jadeqwang
 ---
 
-Have an [Oasis account](http://oasis.sandstorm.io) already? If not, you can [sign up for one right now](https://sandstorm.io/get) and start using it to install any of the 48 apps in the [Sandstorm App Market](http://apps.sandstorm.io). (You can also [use your own Linux box](https://sandstorm.io/get#self-hosting), of course.)
+Have an [Oasis account](http://oasis.sandstorm.io) already? If not, you can [sign up for one right now](https://sandstorm.io/get) and start using it to install any of the 48 apps in the [Sandstorm App Market](http://apps.sandstorm.io). (You can also [use your own Linux box](https://sandstorm.io/get), of course.)
 
 App authors in the [Sandstorm community](https://sandstorm.io/community) have been exceptionally productive lately, packaging their favorite apps and writing original apps as well. I wanted to share some of my recent favorites with you. Here are some brand new apps you should install on your Sandstorm server today:
 

--- a/_posts/2016-06-13-photo-library-lychee.md
+++ b/_posts/2016-06-13-photo-library-lychee.md
@@ -15,7 +15,7 @@ There are at least a couple of different scenarios where you'd want to create a 
 
 In any case where you need to create a shared photo library using Lychee, you can follow these steps:
 
-<h3>1. Get Sandstorm by <a href="https://oasis.sandstorm.io/">signing up for Oasis</a> or <a href="https://sandstorm.io/get#self-hosting">installing it on your own machine.</a><h3>
+<h3>1. Get Sandstorm by <a href="https://oasis.sandstorm.io/">signing up for Oasis</a> or <a href="https://sandstorm.io/get">installing it on your own machine.</a><h3>
 
 <h3>2. Install Lychee from the <a href="https://apps.sandstorm.io">App Market</a></h3>
 <img src="/news/images/lychee-1.png">

--- a/_posts/2016-08-31-sandstorm-for-work-ready.md
+++ b/_posts/2016-08-31-sandstorm-for-work-ready.md
@@ -35,7 +35,7 @@ We only think you should be paying for Sandstorm if it is helping you make money
 * **Non-profits** with paid employees can receive Sandstorm for Work at half price: $5/user/month.
 * **Educational institutions** supporting faculty and students pay $5/month for each faculty member and $1/month for each student.
 * **Volunteer groups** can receive Sandstorm for Work completely free.
-* **Home users** can also receive Sandstorm for Work for free; if you run an LDAP server for your own family, then we want your Sandstorm server to be able to take advantage of it.
+* **Home users** can also receive Sandstorm for Work for free; if you run an LDAP or SAML server for your own family, then we want your Sandstorm server to be able to take advantage of it.
 * **Bulk discounts** are available for large organizations and resellers.
 
 If any of these situations describe you, [tell us about it](mailto:sales@sandstorm.io) and we'll set you up.

--- a/business.html
+++ b/business.html
@@ -28,12 +28,12 @@ title: "Sandstorm Business Features"
         <span class="image"></span><div class="content"><h3><strong>On-prem deployment</strong></h3><p>Get the ease-of-use of SaaS while keeping your data in-house. Deploy to physical machines or any private or public cloud.</p></div>
         </div>
     <li class="ldap">
-      <h3><strong>LDAP and Active Directory integration</strong></h3>
+      <h3><strong>LDAP, SAML and Active Directory integration</strong></h3>
         <p>Let employees log in with their company-wide credentials.</p>
       
     <li class="group">
       <h3><strong>Group Management</strong></h3>
-      <p>Use LDAP/AD groups for sharing and access control.</p>
+      <p>Use LDAP, SAML, AD groups for sharing and access control.</p>
     <li class="global">
       <h3><strong>Global Access Control</strong></h3>
       <p>Set organization-wide access control policies, such as prohibiting your employees from sharing grains outside of the organization. (Coming soon.)</p>

--- a/business.html
+++ b/business.html
@@ -8,8 +8,8 @@ title: "Sandstorm Business Features"
   <h1>Features</h1>
   <div>
       <nav>
-        <a href="/features">Core &amp; Security</a>
-        <a href="/business" class="current">Business</a>
+        <a href="/features">Sandstorm Standard</a>
+        <a href="/business" class="current">Sandstorm for Work</a>
         <a href="/developer">Developer</a>
       </nav>
   </div>
@@ -19,9 +19,9 @@ title: "Sandstorm Business Features"
 
 <section id="business-scale">
   <h2>Sandstorm for Work</h2>
-  <h3>Sandstorm for Work extends Sandstorm with features that businesses need.</h3>
-  <p>Priced at $15/user/month. Special pricing available for <a href="https://docs.sandstorm.io/en/latest/administering/for-work/#special-pricing">
-      non-profits.</a> Currently in Beta.</p>
+  <h3>Includes everything in <a href="/features.html">Sandstorm Standard</a> with additional features your business needs.</h3>
+  <p>Priced at $10/user/month. Special pricing available for <a href="https://docs.sandstorm.io/en/latest/administering/for-work/#special-pricing">
+      non-profits.</a></p>
 <ul id="business">
     <li class="on-prem">
       <div class="row">
@@ -33,7 +33,7 @@ title: "Sandstorm Business Features"
       
     <li class="group">
       <h3><strong>Group Management</strong></h3>
-      <p>Use LDAP/AD groups for sharing and access control. (Coming soon.)</p>
+      <p>Use LDAP/AD groups for sharing and access control.</p>
     <li class="global">
       <h3><strong>Global Access Control</strong></h3>
       <p>Set organization-wide access control policies, such as prohibiting your employees from sharing grains outside of the organization. (Coming soon.)</p>

--- a/developer.html
+++ b/developer.html
@@ -8,8 +8,8 @@ title: "Sandstorm Developer Features"
   <h1>Features</h1>
   <div>
     <nav>
-      <a href="/features">Core &amp; Security</a>
-      <a href="/business">Business</a>
+      <a href="/features">Sandstorm Standard</a>
+      <a href="/business">Sandstorm for Work</a>
       <a href="/developer" class="current">Developer</a>
     </nav>
   </div>

--- a/developer.html
+++ b/developer.html
@@ -50,7 +50,7 @@ title: "Sandstorm Developer Features"
       <p>Sandstorm will start a new instance of your app for each one.
     <li class="integration">
       <h3><strong>Enterprise integration</strong></h3>
-      <p><strong>You don’t have to implement “enterprise” features like audit logging, encryption, LDAP integration, or compliance</strong>
+      <p><strong>You don’t have to implement “enterprise” features like audit logging, encryption, LDAP &amp; SAML integration, or compliance</strong>
       <p>Sandstorm takes care of that for you.
     <li class="in-app">
       <h3><strong>In-app Billing</strong></h3>

--- a/features.html
+++ b/features.html
@@ -8,8 +8,8 @@ title: Sandstorm Features
   <h1>Features</h1>
   <div>
       <nav>
-        <a href="/features" class="current">Core &amp; Security</a>
-        <a href="/business">Business</a>
+        <a href="/features" class="current">Sandstorm Standard</a>
+        <a href="/business">Sandstorm for Work</a>
         <a href="/developer">Developer</a>
       </nav>
   </div>
@@ -40,12 +40,6 @@ var appCount = "Dozens of";
 <section id="core-features">
   <h2>Core Features</h2>
   <ul id="core">
-      <li class="choose-host">
-        <h3><strong>Choose your host</strong></h3>
-        <p>You decide where your data lives.
-        <p>Don't want to set up a server? Use ours at <a href="https://oasis.sandstorm.io/">Sandstorm Oasis</a>, or try one of our hosting partners located all over the world.
-        <p>Want more control? Run your own Sandstorm server <a href="/get#self-hosting">on your own hardware</a>. If you like, we'll set you up with free dynamic DNS and HTTPS certificates on a subdomain of Sandcats.io, or if you prefer you can set up Sandstorm on your own domain.
-        <p>If you change your mind later, you can move your apps and data between hosts at any time.
 
       <li class="apps-growing">
         <h3><strong><script type="text/javascript">document.write(appCount)</script> apps and growing</strong></h3>

--- a/get.html
+++ b/get.html
@@ -19,22 +19,34 @@ title: Get Sandstorm
           <div class="offer"></div>
           <li class="price"><strong>$0-$24</strong><br>/ user / month - billed monthly</strong>
           <li class="features">
-          <ul id="highlight">
+          <ul class="highlight">
             <li>Sandstorm.io-hosted
             <li>Administered by Sandstorm.io
-            <li>Email support
+            <li>Community support
+            <li class="get"><a href="https://oasis.sandstorm.io/">Sign up for Free</a>
           </ul>
-          <ul id="feature-list">
+          <ul class="feature-list">
+            <li class="list-title"><a href="/features">Sandstorm Standard features</a></li>
+            <ul class="sub-list">
             <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
-            <li>Single sign-on to access all apps
-            <li>Collaborate with anyone on the server
-            <li><a href="/features">Sandstorm Standard features</a></li>
+              <li>Single sign-on to access all apps
+              <li>Collaborate with anyone on the server
+              <li>Guest access
+              <li>Individual app sandboxing
+              <li>Automatic app updates
+              <li>App notifications
+              <li>Multi-app search
+              <li>One-click backups
+            </ul>
             <ul class="non-features">
-              <li>Sandstorm for Work features
+              <li class="list-title">Sandstorm for Work features</li>
+              <ul class="sub-list">
+                <li>Organization-wide access control
+                <li>ActiveDirectory/LDAP/SAML integration
+                <li>Personalization &amp; whitelabeling
+              </ul>
             </ul>
           </ul>
-          <li class="get"><a href="https://oasis.sandstorm.io/">Sign up for Free</a>
-          </li>
         </ul>
     </li>
       
@@ -44,45 +56,69 @@ title: Get Sandstorm
           <div class="offer"></div>
           <li class="price"><strong>$0</strong><br>Forever free</strong>
           <li class="features">
-          <ul id="highlight">
+          <ul class="highlight">
             <li>Self-hosted
             <li>Administered by you
-            <li>Email support
+            <li>Community support
+            <li class="get"><a href="https://sandstorm.io/install">Download &amp; Install</a>
           </ul>
-          <ul id="feature-list">
+          <ul class="feature-list">
+            <li class="list-title"><a href="/features">Sandstorm Standard features</a></li>
+            <ul class="sub-list">
             <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
-            <li>Single sign-on to access all apps
-            <li>Collaborate with anyone on the server
-            <li><a href="/features">Sandstorm Standard features</a></li>
+              <li>Single sign-on to access all apps
+              <li>Collaborate with anyone on the server
+              <li>Guest access
+              <li>Individual app sandboxing
+              <li>Automatic app updates
+              <li>App notifications
+              <li>Multi-app search
+              <li>One-click backups
+            </ul>
             <ul class="non-features">
-              <li>Sandstorm for Work features
+              <li class="list-title">Sandstorm for Work features</li>
+              <ul class="sub-list">
+                <li>Organization-wide access control
+                <li>ActiveDirectory/LDAP/SAML integration
+                <li>Personalization &amp; whitelabeling
+              </ul>
             </ul>
           </ul>
-          <li class="get"><a href="https://sandstorm.io/install">Download &amp; Install</a>
-          </li>
       </ul>
     </li>
     
     <li class="plans">
       <ul id="organizations">
-          <li class="title"><strong>Sandstorm for Work</strong><p>Host Sandstorm on-prem. Comes with <a href="/business.html">features that your business needs</a>.</p><img src="/images/get-organizations.svg">
+          <li class="title"><strong>Sandstorm for Work</strong><p><a href="/business.html">Organization-wide access control and login integration</a> for your business.</p><img src="/images/get-organizations.svg">
           <div class="offer">Introductory Offer - Save 50%</div>
           <li class="price"><strong><s class="old-price">$10</s>$5</strong><br>/ user / month - billed annually</strong>
           <li class="features">
-          <ul id="highlight">
+          <ul class="highlight">
             <li>Self-hosted
             <li>Administered by your IT team
             <li>Priority email support
+            <li class="get"><a href="https://sandstorm.io/get-feature-key">Start a Free Trial</a>
           </ul>
-          <ul id="feature-list">
-            <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
-            <li>Single sign-on to access all apps
-            <li>Collaborate with anyone on the server
-            <li><a href="/features">Sandstorm Standard features</a></li>
-            <li><a href="/business.html">Sandstorm for Work features</a></li>
+          <ul class="feature-list">
+            <li class="list-title"><a href="/features">Sandstorm Standard features</a></li>
+            <ul class="sub-list">
+              <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
+              <li>Single sign-on to access all apps
+              <li>Collaborate with anyone on the server
+              <li>Guest access
+              <li>Individual app sandboxing
+              <li>Automatic app updates
+              <li>App notifications
+              <li>Multi-app search
+              <li>One-click backups
+            </ul>
+            <li class="list-title"><a href="/business.html">Sandstorm for Work features</a></li>
+            <ul class="sub-list">
+              <li>Organization-wide access control
+              <li>ActiveDirectory/LDAP/SAML integration
+              <li>Personalization &amp; whitelabeling
+            </ul>
           </ul>
-          <li class="get"><a href="https://sandstorm.io/get-feature-key">Start a Free Trial</a>
-          </li>
       </ul>
   </li>
 

--- a/get.html
+++ b/get.html
@@ -9,85 +9,86 @@ title: Get Sandstorm
     <p>Start using Sandstorm for free right away and collaborate with others</p>
 </header>
 
-<section id="where">
-  <a href="#self-hosting">Self-host</a>
-  <a href="#managed-hosting">Managed Hosting</a>
-</section>
-
-<section id="self-hosting">
-    <h2>Install Sandstorm on your own Server.</h2>
+<section id="plan-table">
+    <h2>Run Sandstorm anywhere.</h2>
     <ul id class="plans">
-    <li class="plan2">
-        <ul id="self-host">
-            <li class="title"><strong>Standard</strong><br><p>Sandstorm is <a href="https://github.com/sandstorm-io/sandstorm">open source</a> and runs on any Linux x86-64 server. Free dynamic DNS &amp; SSL certificates.</p><img src="/images/get-self-host.svg">
-            <li class="price"><strong>$0</strong><br>/user/month
-            <li class="storage"><strong>Storage is up to you!</strong>
-            <li class="grains">Unlimited grains</li>
-            <li class="get"><a href="/install">Download &amp; Install</a></li>
+      
+      <li class="plans">
+        <ul id="oasis">
+          <li class="title"><strong>Sandstorm on Oasis</strong><p>Never worry about running servers—we'll host your Sandstorm for you.</p><img src="/images/get-oasis.svg">
+          <div class="offer"></div>
+          <li class="price"><strong>$0-$24</strong><br>/ user / month - billed monthly</strong>
+          <li class="features">
+          <ul id="highlight">
+            <li>Sandstorm.io-hosted
+            <li>Administered by Sandstorm.io
+            <li>Email support
+          </ul>
+          <ul id="feature-list">
+            <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
+            <li>Single sign-on to access all apps
+            <li>Collaborate with anyone on the server
+            <li><a href="/features">Sandstorm Standard features</a></li>
+            <ul class="non-features">
+              <li>Sandstorm for Work features
+            </ul>
+          </ul>
+          <li class="get"><a href="https://oasis.sandstorm.io/">Sign up for Free</a>
+          </li>
         </ul>
     </li>
+      
+    <li class="plans">
+      <ul id="self-hosting">
+        <li class="title"><strong>Sandstorm Standard</strong><p>Host Sandstorm on your own server with invite-only access.</p><img src="/images/get-self-host.svg">
+          <div class="offer"></div>
+          <li class="price"><strong>$0</strong><br>Forever free</strong>
+          <li class="features">
+          <ul id="highlight">
+            <li>Self-hosted
+            <li>Administered by you
+            <li>Email support
+          </ul>
+          <ul id="feature-list">
+            <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
+            <li>Single sign-on to access all apps
+            <li>Collaborate with anyone on the server
+            <li><a href="/features">Sandstorm Standard features</a></li>
+            <ul class="non-features">
+              <li>Sandstorm for Work features
+            </ul>
+          </ul>
+          <li class="get"><a href="https://sandstorm.io/install">Download &amp; Install</a>
+          </li>
+      </ul>
+    </li>
     
-    <li class="plan2">
-    <ul id="organizations">
-        <li class="title"><strong>Sandstorm for Work</strong><br><p><a href="/business">Sandstorm for Work</a> adds features and integrations that businesses need. Comes with SAML &amp; LDAP.</p><img src="/images/get-organizations.svg">
-        <li class="price"><div class="offer">Introductory Offer - Save 50%</div><strong><s class="old-price">$10</s>$5</strong><br>/user/month - billed annually</strong>
-        <li class="storage"><strong>Storage is up to you!</strong>
-        <li class="grains">Unlimited grains</li>
-        <li class="get"><a href="https://sandstorm.io/get-feature-key">Start a Free Trial</a></li>
-    </ul>
-</li>
-</ul>
+    <li class="plans">
+      <ul id="organizations">
+          <li class="title"><strong>Sandstorm for Work</strong><p>Host Sandstorm on-prem. Comes with <a href="/business.html">features that your business needs</a>.</p><img src="/images/get-organizations.svg">
+          <div class="offer">Introductory Offer - Save 50%</div>
+          <li class="price"><strong><s class="old-price">$10</s>$5</strong><br>/ user / month - billed annually</strong>
+          <li class="features">
+          <ul id="highlight">
+            <li>Self-hosted
+            <li>Administered by your IT team
+            <li>Priority email support
+          </ul>
+          <ul id="feature-list">
+            <li>Use any app on the <a href="https://apps.sandstorm.io">App Market</a>
+            <li>Single sign-on to access all apps
+            <li>Collaborate with anyone on the server
+            <li><a href="/features">Sandstorm Standard features</a></li>
+            <li><a href="/business.html">Sandstorm for Work features</a></li>
+          </ul>
+          <li class="get"><a href="https://sandstorm.io/get-feature-key">Start a Free Trial</a>
+          </li>
+      </ul>
+  </li>
 
 </section>
 
 <div class="action">
-    <li>Questions?</li><a href="mailto:contact@sandstorm.io">E-mail us</a>
+  <li>Let us help you get the most out of Sandstorm
+  </li><a href="mailto:contact@sandstorm.io">E-mail us</a>
 </div>
-
-<section id="managed-hosting">
-    <h2>Sandstorm Oasis: Hosting by Sandstorm.io</h2>
-    <h3>Which plan is right for you?</h3>
-
-    <ul>
-        <li class="plan1">
-            <ul class="free">
-                <li class="title"><strong>Free</strong>
-                    <br>Host on Oasis</li>
-                <li class="price"><strong>$0</strong>
-                    <br>/forever</li>
-                <li class="storage"><strong>200MB</strong>
-                    <br>storage</li>
-                <li class="grains">5 grains</li>
-                <li class="get"><a href="https://oasis.sandstorm.io/">Get Free</a></li>
-            </ul>
-        </li>
-        <li class="plan1">
-            <ul class="standard">
-                <li class="title"><strong>Basic</strong>
-                    <br>Host on Oasis</li>
-                <li class="price"><strong>$9</strong>
-                    <br>/month</li>
-                <li class="storage"><strong>10GB</strong>
-                    <br>storage</li>
-                <li class="grains">Unlimited grains</li>
-                <li class="get"><a href="https://oasis.sandstorm.io/">Get Standard</a></li>
-            </ul>
-        </li>
-        <li class="plan1">
-            <ul class="power">
-                <li class="title"><strong>Power User</strong>
-                    <br>Host on Oasis</li>
-                <li class="price"><strong>$24</strong>
-                    <br>/month</li>
-                <li class="storage"><strong>100GB</strong>
-                    <br>storage</li>
-                <li class="grains">Unlimited grains</li>
-                <li class="get"><a href="https://oasis.sandstorm.io/">Get Power-User</a></li>
-            </ul>
-        </li>
-    </ul>
-
-    <div class="action">
-        <a href="https://oasis.sandstorm.io/">Start on Oasis for Free</a><li>&amp; upgrade when you want</li>
-    </div>
-</section>

--- a/images/check-dark.svg
+++ b/images/check-dark.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 15 12.5" style="enable-background:new 0 0 15 12.5;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#B792DD;}
+	.st0{fill:#5B4F8C;}
 </style>
 <polygon class="st0" points="13.3,3.1 11.6,1.7 6.1,7.9 3.3,5.4 1.8,7.1 6.3,11.1 "/>
 </svg>

--- a/images/check.svg
+++ b/images/check.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 15 12.5" style="enable-background:new 0 0 15 12.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#A178C4;}
+</style>
+<polygon class="st0" points="13.3,3.1 11.6,1.7 6.1,7.9 3.3,5.4 1.8,7.1 6.3,11.1 "/>
+</svg>

--- a/images/get-oasis.svg
+++ b/images/get-oasis.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 300 206" style="enable-background:new 0 0 300 206;" xml:space="preserve">
+<style type="text/css">
+	.st0{filter:url(#Adobe_OpacityMaskFilter);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{mask:url(#SVGID_1_);}
+	.st3{fill:#542866;}
+</style>
+<defs>
+	<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="69.9" y="3.4" width="196.5" height="202.6">
+		<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+	</filter>
+</defs>
+<mask maskUnits="userSpaceOnUse" x="69.9" y="3.4" width="196.5" height="202.6" id="SVGID_1_">
+	<g class="st0">
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="4824.9102" y1="5442.1821" x2="5046.1978" y2="5220.895" gradientTransform="matrix(-1 0 0 -1 5101.4448 5433.3335)">
+			<stop  offset="0" style="stop-color:#000000"/>
+			<stop  offset="2.729893e-003" style="stop-color:#010101"/>
+			<stop  offset="0.124" style="stop-color:#3C3C3C"/>
+			<stop  offset="0.2478" style="stop-color:#707070"/>
+			<stop  offset="0.3721" style="stop-color:#9C9C9C"/>
+			<stop  offset="0.4965" style="stop-color:#C0C0C0"/>
+			<stop  offset="0.6212" style="stop-color:#DBDBDB"/>
+			<stop  offset="0.7463" style="stop-color:#EFEFEF"/>
+			<stop  offset="0.8721" style="stop-color:#FBFBFB"/>
+			<stop  offset="1" style="stop-color:#FFFFFF"/>
+		</linearGradient>
+		<polygon class="st1" points="60,-13.6 271.8,-13.6 271.8,217.2 60,217.2 		"/>
+	</g>
+</mask>
+<g class="st2">
+	<g>
+		<g>
+			<polygon class="st3" points="107.8,94.3 107.8,101.8 115.3,101.8 116.1,101.8 123.6,101.8 123.6,101.8 131.1,101.8 138.6,101.8 
+				138.6,93.6 138.6,86.1 131.1,86.1 131.1,78.6 123.6,78.6 123.6,71 116.1,71 115.3,71 107.8,71 107.8,78.6 107.8,79.3 107.8,86.8 
+				107.8,86.8 			"/>
+		</g>
+		<g>
+			<rect x="165.9" y="24.9" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="133.2,83.5 141.5,83.5 141.5,75.2 133.3,75.2 133.3,67 125,67 125,75.3 133.2,75.3 			"/>
+		</g>
+		<g>
+			<polygon class="st3" points="147.8,76 147.8,76.8 147.8,83.5 147.8,84.3 147.8,91.8 155.3,91.8 156.1,91.8 162.8,91.8 
+				163.6,91.8 171.1,91.8 171.1,91.8 178.6,91.8 178.6,83.5 171.1,83.5 171.1,76 163.6,76 163.6,68.5 156.1,68.5 156.1,61 147.8,61 
+				147.8,69.3 			"/>
+		</g>
+		<g>
+			<rect x="159" y="54" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="201.1" y="9.2" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="167.8" y="63.1" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="244,17.6 244,9.3 239.5,9.3 239.5,3.4 231.3,3.4 231.3,11.7 235.7,11.7 235.7,17.6 			"/>
+		</g>
+		<g>
+			<rect x="216.7" y="26.4" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="176.4" y="71.8" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="139.8,110.6 139.8,111.3 139.8,118.1 139.8,118.8 139.8,126.3 139.8,126.3 139.8,133.8 147.3,133.8 
+				148.1,133.8 154.8,133.8 155.6,133.8 162.3,133.8 163.1,133.8 170.6,133.8 170.6,126.3 170.6,125.6 170.6,118.1 163.1,118.1 
+				163.1,110.6 155.6,110.6 155.6,103 147.3,103 139.8,103 			"/>
+		</g>
+		<g>
+			<polygon class="st3" points="157.6,99.6 157.6,107.8 165.8,107.8 165.8,116 174.1,116 174.1,107.8 165.8,107.8 165.8,99.6 			"/>
+		</g>
+		<g>
+			<rect x="222.4" y="47.3" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="213.1,68 211.3,68 211.3,62.7 205.6,62.7 205.6,60.5 198.1,60.5 198.1,53 189.8,53 189.8,60.5 
+				189.8,60.5 189.8,68.8 189.8,75.5 189.8,76.3 189.8,83.8 198.1,83.8 198.1,83.8 204.9,83.8 204.9,83.8 213.1,83.8 220.6,83.8 
+				220.6,75.5 213.1,75.5 			"/>
+		</g>
+		<g>
+			<rect x="193.9" y="88.9" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="241.8" y="47.4" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="202.3" y="97.6" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="266.3,33.6 258.1,33.6 258.1,36.8 257.3,36.8 257.3,45 265.5,45 265.5,41.8 266.3,41.8 			"/>
+		</g>
+		<g>
+			<rect x="246" y="65.3" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="211.5" y="106.4" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="205.1,117.5 205.1,110 197.6,110 197.6,102.5 190.1,102.5 190.1,95 181.8,95 181.8,103.3 181.8,110 
+				181.8,110.8 181.8,117.5 181.8,118.3 181.8,125.8 189.3,125.8 190.1,125.8 196.8,125.8 197.6,125.8 204.3,125.8 205.1,125.8 
+				212.6,125.8 212.6,117.5 			"/>
+		</g>
+		<g>
+			<rect x="190.2" y="132.1" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="241.3" y="99.9" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<rect x="198.4" y="140.4" class="st3" width="8.3" height="8.3"/>
+		</g>
+		<g>
+			<polygon class="st3" points="202.6,150.1 195.1,150.1 195.1,142.5 187.6,142.5 187.6,135 179.3,135 171.8,135 171.8,143.3 
+				171.8,150.1 171.8,150.8 171.8,157.6 171.8,158.3 171.8,165.8 180.1,165.8 186.8,165.8 187.6,165.8 194.3,165.8 195.1,165.8 
+				202.6,165.8 202.6,157.6 202.6,157.6 			"/>
+		</g>
+		<g>
+			<polygon class="st3" points="162.9,173 162.9,143 132.9,143 132.9,112.9 102.9,112.9 102.9,82.9 69.9,82.9 69.9,115.9 
+				69.9,115.9 69.9,146 69.9,146 69.9,173 69.9,173 69.9,206 102.9,206 102.9,206 132.9,206 132.9,206 162.8,206 162.8,206 
+				195.8,206 195.8,173 			"/>
+		</g>
+	</g>
+</g>
+</svg>

--- a/images/get-organizations.svg
+++ b/images/get-organizations.svg
@@ -1,37 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 300 206" style="enable-background:new 0 0 300 206;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#5A69A0;}
 	.st1{fill:#A8B6DD;}
-	.st2{opacity:0.6;fill:#A8B6DD;}
-	.st3{opacity:0.3;fill:#A8B6DD;}
-	.st4{opacity:0.1;fill:#A8B6DD;}
+	.st2{opacity:0.6;fill:#A8B6DD;enable-background:new    ;}
+	.st3{opacity:0.3;fill:#A8B6DD;enable-background:new    ;}
+	.st4{opacity:0.1;fill:#A8B6DD;enable-background:new    ;}
 </style>
-<rect x="102" y="149" class="st0" width="78" height="57"/>
-<rect y="175" class="st0" width="78" height="31"/>
-<rect x="59" y="61" class="st0" width="87" height="145"/>
-<rect x="170" class="st0" width="86" height="206"/>
-<rect x="223" y="99" class="st0" width="77" height="107"/>
-<rect x="177.7" y="10.4" class="st1" width="31.1" height="12.9"/>
-<rect x="216.2" y="10.4" class="st1" width="31.1" height="12.9"/>
-<rect x="177.7" y="29.1" class="st1" width="31.1" height="12.9"/>
-<rect x="216.2" y="29.1" class="st2" width="31.1" height="12.9"/>
-<rect x="68.4" y="69.9" class="st1" width="31.1" height="12.9"/>
-<rect x="106.9" y="69.9" class="st1" width="31.1" height="12.9"/>
-<rect x="68.4" y="88.6" class="st1" width="31.1" height="12.9"/>
-<rect x="106.9" y="88.6" class="st2" width="31.1" height="12.9"/>
-<rect x="68.4" y="108.2" class="st2" width="31.1" height="12.9"/>
-<rect x="106.9" y="108.2" class="st2" width="31.1" height="12.9"/>
-<rect x="106.9" y="126.9" class="st3" width="31.1" height="12.9"/>
-<rect x="68.4" y="126.9" class="st3" width="31.1" height="12.9"/>
-<rect x="68.4" y="145.2" class="st3" width="31.1" height="12.9"/>
-<rect x="177.7" y="48.5" class="st2" width="31.1" height="12.9"/>
-<rect x="216.2" y="48.5" class="st2" width="31.1" height="12.9"/>
-<rect x="177.7" y="67.2" class="st3" width="31.1" height="12.9"/>
-<rect x="216.2" y="67.2" class="st3" width="31.1" height="12.9"/>
-<rect x="216.2" y="85.7" class="st4" width="31.1" height="12.9"/>
-<rect x="177.7" y="85.7" class="st3" width="31.1" height="12.9"/>
-<rect x="177.7" y="104.4" class="st4" width="31.1" height="12.9"/>
+<polygon class="st0" points="256,100 256,1 170,1 170,150 146,150 146,62 59,62 59,176 0,176 0,186.3 0,207 300,207 300,186.3 
+	300,100 "/>
+<title>get-organizations</title>
+<rect x="177.7" y="11.4" class="st1" width="31.1" height="12.9"/>
+<rect x="216.2" y="11.4" class="st1" width="31.1" height="12.9"/>
+<rect x="177.7" y="30.1" class="st1" width="31.1" height="12.9"/>
+<rect x="216.2" y="30.1" class="st2" width="31.1" height="12.9"/>
+<rect x="68.4" y="70.9" class="st1" width="31.1" height="12.9"/>
+<rect x="106.9" y="70.9" class="st1" width="31.1" height="12.9"/>
+<rect x="68.4" y="89.6" class="st1" width="31.1" height="12.9"/>
+<rect x="106.9" y="89.6" class="st2" width="31.1" height="12.9"/>
+<rect x="68.4" y="109.2" class="st2" width="31.1" height="12.9"/>
+<rect x="106.9" y="109.2" class="st2" width="31.1" height="12.9"/>
+<rect x="106.9" y="127.9" class="st3" width="31.1" height="12.9"/>
+<rect x="68.4" y="127.9" class="st3" width="31.1" height="12.9"/>
+<rect x="68.4" y="146.2" class="st3" width="31.1" height="12.9"/>
+<rect x="177.7" y="49.5" class="st2" width="31.1" height="12.9"/>
+<rect x="216.2" y="49.5" class="st2" width="31.1" height="12.9"/>
+<rect x="177.7" y="68.2" class="st3" width="31.1" height="12.9"/>
+<rect x="216.2" y="68.2" class="st3" width="31.1" height="12.9"/>
+<rect x="216.2" y="86.7" class="st4" width="31.1" height="12.9"/>
+<rect x="177.7" y="86.7" class="st3" width="31.1" height="12.9"/>
+<rect x="177.7" y="105.4" class="st4" width="31.1" height="12.9"/>
 </svg>

--- a/images/get-self-host.svg
+++ b/images/get-self-host.svg
@@ -1,26 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 19.2.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 300 206" style="enable-background:new 0 0 300 206;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#7285BA;}
-	.st1{fill:#5A69A0;}
-	.st2{fill:#A8B6DD;}
-	.st3{clip-path:url(#SVGID_2_);fill:#A8B6DD;}
+	.st0{fill:#B46E91;}
+	.st1{fill:#965F82;}
+	.st2{fill:#DBA4C3;}
 </style>
 <rect x="72.3" y="47" class="st0" width="28.7" height="45.3"/>
 <polygon class="st1" points="148.4,37 30.7,120.9 72.8,120.9 72.8,206.8 222,206.8 222,120.9 266,120.9 "/>
 <rect x="126.1" y="145.6" class="st2" width="43.7" height="61.2"/>
 <g>
-	<defs>
-		<rect id="SVGID_1_" x="209" y="170" width="73" height="36"/>
-	</defs>
-	<clipPath id="SVGID_2_">
-		<use xlink:href="#SVGID_1_"  style="overflow:visible;"/>
-	</clipPath>
-	<path class="st3" d="M252.9,184.1c0,0-3.3-7.8-15.2-7.5c-12,0.4-3.2,9.8-3.2,9.8s-13.7-1.6-16.1,2.7c-2.9,5.3,1.1,7.1,1.1,7.1
-		l-3.9,0.8c0,0,4.6,3.1,6.1,3c1.5-0.1-9.6,3.9-7.1,8.2c2.6,4.4,7.7,5.4,13.7,3.6c6-1.8,2.4,0,2.4,0s-4.8,4,14.2,4
-		c19,0,12.7-5,12.7-5s16.2-0.5,17.9-4c1.7-3.4-1.3-5.6-2.8-6.8c-1.5-1.2-3.6-2.5-3.6-2.5s5.6-0.7,6.4-3.4c0.8-2.7,0.8-2.7,0.8-2.7
-		l-4.2,0.3c0,0,3.6-4.5-2.4-8.7c-6-4.2-10.8,1.1-10.8,1.1s0-3-3-4.1c-3-1.1-3-1.1-3-1.1S254.9,182.5,252.9,184.1z"/>
+	<path class="st2" d="M272.7,200c-1.5-1.2-3.6-2.5-3.6-2.5s5.6-0.7,6.4-3.4c0.8-2.7,0.8-2.7,0.8-2.7l-4.2,0.3c0,0,3.6-4.5-2.4-8.7
+		c-6-4.2-10.8,1.1-10.8,1.1s0-3-3-4.1c-3-1.1-3-1.1-3-1.1s2,3.6,0,5.2c0,0-3.3-7.8-15.2-7.5c-12,0.4-3.2,9.8-3.2,9.8
+		s-13.7-1.6-16.1,2.7c-2.9,5.3,1.1,7.1,1.1,7.1l-3.9,0.8c0,0,4.6,3.1,6.1,3c1.3-0.1-7.3,3.1-7.5,6.8h61.3
+		C277.2,203.4,274.2,201.2,272.7,200z"/>
 </g>
 </svg>

--- a/images/xmark.svg
+++ b/images/xmark.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 15 12.5" style="enable-background:new 0 0 15 12.5;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B2B2B2;}
+</style>
+<polygon class="st0" points="12.6,3 10.9,1.2 2.4,9.6 4.1,11.4 "/>
+<polygon class="st0" points="10.8,11.5 12.6,9.8 4.2,1.2 2.4,2.9 "/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@ title: Sandstorm
     </header>
 
     <section class="hosting">
-      <p><strong>You choose where your data lives:</strong> You can use Sandstorm in the cloud on a variety of hosting services, or you can <a href="/get#self-hosting">install it on your own machines.</a> You can even move between these options at any time. No matter where you decide to run Sandstorm, the apps are the same.
+      <p><strong>You choose where your data lives:</strong> You can use Sandstorm in the cloud on a variety of hosting services, or you can <a href="/get">install it on your own machines.</a> You can even move between these options at any time. No matter where you decide to run Sandstorm, the apps are the same.
     </section>
 
     <section class="walled-gardens">
@@ -111,7 +111,7 @@ title: Sandstorm
 
   <section class="individual">
     <h3>Individuals</h3>
-    <p>Sandstorm makes it safe &amp; easy to use indie web apps. It adds security hardening to protect your privacy. Apps never disappear, and you can add your own. Run your <a href="/get#self-hosting">own server</a> or use <a href="/get#managed-hosting">our hosting.</a>
+    <p>Sandstorm makes it safe &amp; easy to use indie web apps. It adds security hardening to protect your privacy. Apps never disappear, and you can add your own. Run your <a href="/get">own server</a> or use <a href="/get">our hosting.</a>
     <p><a class="start" href="/features">Learn More</a>
     <div>
     </div>

--- a/style.scss
+++ b/style.scss
@@ -1521,12 +1521,9 @@ body >footer {
         border: 1px solid #dbcdea;
         border-radius: 5px;
         margin: 0 2% 20px 0;
-        width: 31%;
+        width: 32%;
         position: relative;
         color: #684599;
-        @media (max-width: 800px) {
-          width: 32%;
-        }
         @media (max-width: 750px) {
           width: 47%;
         }
@@ -1556,7 +1553,7 @@ body >footer {
         }
         .get {
           border-radius: 0px 0px 5px 5px;
-          padding: 15px 0;
+          padding: 12px 0;
           display: flex;
           flex: 1;
           flex-direction: column;
@@ -1573,7 +1570,7 @@ body >footer {
           font-size: 20px;
           border-radius: 5px;
           width: 90%;
-          padding: 12px 0;
+          padding: 5px 0;
           transition: transform 0.75s ease, background 0.35s ease;
           align-self: center;
         }
@@ -1584,44 +1581,22 @@ body >footer {
           margin: 0 auto;
           margin-bottom: 20px;
           >ul {
-            width: 31%;
-            position: relative;
-            flex: 1;
-
-            @media (max-width: 800px) {
-              width: 45%;
-            }
-
-            @media (max-width: 550px) {
-              width: 100%;
-            }
-
+            width: 100%;
             p {
               max-width: 375px;
-              margin: 1em auto;
-            }
-            
+              margin: 0.6em auto;
+            }         
             a {
               text-decoration: none;
             }
-
             .title {
               border-bottom: 1px solid #eee9f4;
               color: #202d70;
-              min-height: 290px;
               border-radius: 5px 5px 0px 0px;
-              padding-top: 17px;
+              padding-top: 11px;
               display: flex;
               flex-direction: column;
-              @media (max-width: 1200px) {
-                padding-top: 15px;
-              }
-              @media (max-width: 900px) {
-                padding-top: 12px;
-              }
-              @media (max-width: 700px) {
-                padding-top: 8px;
-              }
+              justify-content: flex-end;
               strong {
                 padding: 15px 10px 0 10px;
                 font-size: 25px;
@@ -1631,7 +1606,7 @@ body >footer {
                 }
               }
               p {
-                padding: 0 10px;
+                padding: 0 8px;
                 width: 90%;
                 min-height: 70px;
                 @media (max-width: 900px) {
@@ -1687,58 +1662,90 @@ body >footer {
                   font-size: 25px;
                 }
               }
-              #highlight {
+              .highlight {
                 li {
-                  line-height: 2.5em;
+                  line-height: 2.3em;
                   color: #232323;
-                  font-size: 18px;
                   border-bottom: 1px solid #eee9f4;
                   @media (max-width: 900px) and (min-width: 550px) {
                     font-size: 16px;
                   }
                 }
               }
-              #feature-list {
-                padding: 15px 0;
+              .feature-list {
+                padding: 5px 5px 15px 11px;
                 text-align: left;
-                padding-left: 15px;
                 color: #232323;
-                font-size: 17px;
                 line-height: 1.9em;
-                border-bottom: 1px solid #eee9f4;
-                @media (max-width: 1050px) {
-                  font-size: 15px;
-                  padding-left: 12px;
-                }
-                @media (max-width: 950px) {
-                  font-size: 13px;
-                  padding-left: 9px;
-                }
-                @media (max-width: 850px) {
-                  font-size: 12px;
-                }
-                @media (max-width: 750px) {
-                  font-size: 15px;
-                  padding-left: 15px;
-                }
-                @media (max-width: 550px) {
-                  font-size: 17px;
-                }
                 li {
-                  line-height: 2.3em;
+                  line-height: 2.2em;
                   &::before {
+                    width: 21px;
+                    height: 15px;
+                    margin-top: 11px;
                     display: block;
                     content: " ";
                     float: left;
-                    width: 20px;
-                    height: 12px;
-                    margin-top: 12px;
-                    background-image: url(/images/check.svg);
+                    background-image: url(/images/check-dark.svg);
                     background-repeat: no-repeat;
                     background-size: contain;
+                    @media (min-width: 1000px) {
+                      width: 21px;
+                      height: 15px;
+                      margin-top: 13px;
+                  }
                   }
                   a {
                     text-decoration: none;
+                  }
+                }
+                .list-title {
+                  font-size: 21px;
+                  @media (max-width: 1050px) {
+                    font-size: 18px;
+                  }
+                  @media (max-width: 950px) {
+                    font-size: 16px;
+                  }
+                  @media (max-width: 850px) {
+                    font-size: 15px;
+                  }
+                  @media (max-width: 750px) {
+                    font-size: 18px;
+                  }
+                  @media (max-width: 550px) {
+                    font-size: 21px;
+                  }
+                }
+                .sub-list {
+                  margin: 0 4px 5px 18px;
+                  font-size: 16px;
+                  @media (max-width: 1050px) {
+                    font-size: 14px;
+                  }
+                  @media (max-width: 950px) {
+                    font-size: 13px;
+                  }
+                  @media (max-width: 900px) {
+                    font-size: 12px;
+                  }
+                  @media (max-width: 850px) {
+                    font-size: 11px;
+                  }
+                  @media (max-width: 750px) {
+                    font-size: 15px;
+                  }
+                  @media (max-width: 550px) {
+                    font-size: 17px;
+                  }
+                  li {
+                    line-height: 2em;
+                    &::before {
+                      width: 17px;
+                      height: 12px;
+                      margin-top: 9px;
+                      background-image: url(/images/check.svg);
+                    }
                   }
                 }
                 .non-features {

--- a/style.scss
+++ b/style.scss
@@ -1452,46 +1452,53 @@ body >footer {
     padding-top: 20px;
     font-weight: 300;
   }
-
-  #where {
-    display: flex;
-    flex-direction: row;
-    height: 250px;
-    padding: 0;
-
-    >a {
-      display: block;
-      flex: 0 0 50%;
-      height: 100%;
-      text-align: center;
-      font-size: 32px;
-      padding: 24px 0;
-      color: $default-fontcolor;
-
-      &:first-of-type {
-        background: 50% 70px/175px no-repeat url("/images/self-host.svg");
-
-        @media (max-width: 600px) {
-          background-position: 50% 120px;
-          background-size: 125px;
-        }
+  
+  #self-hosting {
+    .title {
+      background-color: #f9eff5;
+    }
+    .offer {
+      background-color: #f9eff5;
+    }
+    .get>a {
+      background-color: #962751;
+      &:hover {
+        background-color: #ae2e5e;
       }
-      &:last-of-type {
-        background: 50% 85px/175px no-repeat url("/images/hosted-service.svg") #efedf9;
-
-        @include stripe-right {
-          background-color: #efedf9;
-        }
-
-        @media (max-width: 600px) {
-          background-position: 50% 120px;
-          background-size: 125px;
-        }
+    }
+  }
+  
+  #organizations {
+    .title {
+      background-color: #eaf2fd;
+    }
+    .offer {
+      background-color: #4e58c8;
+    }
+    .get>a {
+      background-color: #4049a7;
+      &:hover {
+        background-color: #4e58c8;
+      }
+    }
+  }
+  
+  #oasis {
+    .title {
+      background-color: #f5edfd;
+    }
+    .offer {
+      background-color: #f5edfd;
+    }
+    .get>a {
+      background-color: $purplebutton-bg;
+      &:hover {
+        background-color: $purplehover-bg;
       }
     }
   }
 
-  #managed-hosting, #self-hosting {
+  #plan-table {
     text-align: center;
 
     p strong {
@@ -1502,74 +1509,58 @@ body >footer {
       margin: 0;
       padding: 37px 0;
       text-align: center;
+      display: inline-flex;
+      flex-wrap: wrap;
 
       >li {
         list-style: none;
-        display: inline-block;
+        display: inline-flex;
         background: white;
         padding: 0;
         text-align: center;
-        border: 1px solid #8c72b5;
+        border: 1px solid #dbcdea;
         border-radius: 5px;
         margin: 0 2% 20px 0;
-        width: 30%;
+        width: 31%;
         position: relative;
         color: #684599;
-        box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+        @media (max-width: 800px) {
+          width: 32%;
+        }
+        @media (max-width: 750px) {
+          width: 47%;
+        }
+
+        @media (max-width: 550px) {
+          width: 100%;
+        }
 
         ul {
           padding: 0;
+          display: flex;
+          flex-direction: column;
           li {
             list-style: none;
           }
         }
 
-        @media (max-width: 750px) {
-          width: 45%;
-        }
-
-        @media (max-width: 500px) {
-          width: 100%;
-        }
-
         strong {
           color: #4f3070;
         }
-
-        .title {
-          background-color: #ebe7f7;
-          padding: 15px 0;
-          border-radius: 5px 5px 0px 0px;
-
-          p {
-            min-height: 80px;
-          }
-
-          strong {
-            font-size: 30px;
-          }
-        }
         .price {
-          border-bottom: 1px solid #b6b6d8;
+          border-bottom: 1px solid #eee9f4;
           padding: 10px 0;
           strong {
             font-size: 40px;
           }
         }
-        .storage {
-          border-bottom: 1px solid #b6b6d8;
-          padding: 10px 0;
-          strong {
-            font-size: 30px;
-          }
-        }
-        .grains {
-          font-size: 20px;
-          padding: 10px 0 0 0;
-        }
         .get {
           border-radius: 0px 0px 5px 5px;
-          padding: 10px 0;
+          padding: 15px 0;
+          display: flex;
+          flex: 1;
+          flex-direction: column;
+          justify-content: flex-end;
         }
 
         a {
@@ -1581,87 +1572,182 @@ body >footer {
           color: white;
           font-size: 20px;
           border-radius: 5px;
-          display: inline-block;
-          background-color: $purplebutton-bg;
-          width: 95%;
+          width: 90%;
           padding: 12px 0;
           transition: transform 0.75s ease, background 0.35s ease;
-          &:hover {
-            background-color: $purplehover-bg;
-          }
+          align-self: center;
         }
 
-        &.plan2 {
-          margin: 0 2% 20px 2%;
-          width: 45%;
-          position: relative;
-          box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+        &.plans {
+          display: flex;
+          justify-content: center;
+          margin: 0 auto;
+          margin-bottom: 20px;
+          >ul {
+            width: 31%;
+            position: relative;
+            flex: 1;
 
-           @media (max-width: 700px) {
-            width: 100%;
-          }
+            @media (max-width: 800px) {
+              width: 45%;
+            }
 
-          p {
-            max-width: 375px;
-            margin: 1em auto;
-          }
+            @media (max-width: 550px) {
+              width: 100%;
+            }
 
-          #self-host {
+            p {
+              max-width: 375px;
+              margin: 1em auto;
+            }
+            
+            a {
+              text-decoration: none;
+            }
+
+            .title {
+              border-bottom: 1px solid #eee9f4;
+              color: #202d70;
+              min-height: 290px;
+              border-radius: 5px 5px 0px 0px;
+              padding-top: 17px;
+              display: flex;
+              flex-direction: column;
+              @media (max-width: 1200px) {
+                padding-top: 15px;
+              }
+              @media (max-width: 900px) {
+                padding-top: 12px;
+              }
+              @media (max-width: 700px) {
+                padding-top: 8px;
+              }
+              strong {
+                padding: 15px 10px 0 10px;
+                font-size: 25px;
+                color: #202d70;
+                @media (max-width: 900px) {
+                  font-size: 22px;
+                }
+              }
+              p {
+                padding: 0 10px;
+                width: 90%;
+                min-height: 70px;
+                @media (max-width: 900px) {
+                  width: 95%;
+                  font-size: 16px;
+                  padding: 0 6px;
+                }
+                @media (max-width: 550px) {
+                  min-height: 50px;
+                  font-size: 18px;
+                }
+              }
+              img {
+                width: 60%;
+                margin: 0 auto;
+                @media (max-width: 850px) {
+                  width: 70%;
+                }
+                @media (max-width: 700px) {
+                  width: 80%;
+                }
+                @media (max-width: 550px) {
+                  width: 50%;
+                }
+              }
+              .offer {
+                height: 27px;
+                padding: 3px 0;
+                color: #fff;
+                justify-content: flex-end;
+              }
+            }
             .price {
-              padding-top: 28px;
+              border-bottom: 1px solid #eee9f4;
+              padding: 25px 15px 15px 15px;
+              line-height: 2em;
+              @media (max-width: 900px) and (min-width: 550px) {
+                font-size: 14px;
+              }
+              strong {
+                font-size: 50px;
+              }
+              .old-price {
+                color: #b0b0b0;
+                font-size: 80%;
+              }
             }
-          }
-
-          .title {
-            padding: 15px 15px 0 10px;
-            border-bottom: 1px solid #b6b6d8;
-            background: #edf2f9;
-            color: #202d70;
-            strong {
-              font-size: 30px;
-              color: #202d70;
-            }
-            img {
-              height: 150px;
-            }
-          }
-          .price {
-            border-bottom: 1px solid #b6b6d8;
-            padding: 0 0 10px 0;
-            strong {
-              font-size: 40px;
-              color: #202d70;
-            }
-            .old-price {
-              color: #b0b0b0;
-              font-size: 80%;
-            }
-            .offer {
-              padding: 3px 0;
-              color: #fff;
-              background-color: #ad3e73;
-            }
-          }
-          .storage {
-            border-bottom: 1px solid #b6b6d8;
-            strong {
-              font-size: 30px;
-              color: #202d70;
-            }
-          }
-          .grains {
-            color: #202d70;
-          }
-          .get>a {
-            color: white;
-            font-size: 20px;
-            border-radius: 5px;
-            display: inline-block;
-            background-color: #202d70;
-            width: 95%;
-            padding: 15px 0;
-            &:hover {
-              background-color: #274c96;
+            .features {
+              strong {
+                font-size: 30px;
+                color: #202d70;
+                @media (max-width: 800px) {
+                  font-size: 25px;
+                }
+              }
+              #highlight {
+                li {
+                  line-height: 2.5em;
+                  color: #232323;
+                  font-size: 18px;
+                  border-bottom: 1px solid #eee9f4;
+                  @media (max-width: 900px) and (min-width: 550px) {
+                    font-size: 16px;
+                  }
+                }
+              }
+              #feature-list {
+                padding: 15px 0;
+                text-align: left;
+                padding-left: 15px;
+                color: #232323;
+                font-size: 17px;
+                line-height: 1.9em;
+                border-bottom: 1px solid #eee9f4;
+                @media (max-width: 1050px) {
+                  font-size: 15px;
+                  padding-left: 12px;
+                }
+                @media (max-width: 950px) {
+                  font-size: 13px;
+                  padding-left: 9px;
+                }
+                @media (max-width: 850px) {
+                  font-size: 12px;
+                }
+                @media (max-width: 750px) {
+                  font-size: 15px;
+                  padding-left: 15px;
+                }
+                @media (max-width: 550px) {
+                  font-size: 17px;
+                }
+                li {
+                  line-height: 2.3em;
+                  &::before {
+                    display: block;
+                    content: " ";
+                    float: left;
+                    width: 20px;
+                    height: 12px;
+                    margin-top: 12px;
+                    background-image: url(/images/check.svg);
+                    background-repeat: no-repeat;
+                    background-size: contain;
+                  }
+                  a {
+                    text-decoration: none;
+                  }
+                }
+                .non-features {
+                  color: #939393;
+                  li {
+                    &::before { background-image: url(images/xmark.svg); }
+                  }
+                }
+              } 
             }
           }
         }
@@ -3338,3 +3424,4 @@ body >footer {
     }
   }
 }
+


### PR DESCRIPTION
Addresses #221 

Changes in this commit:
- added simplified feature comparisons; emphasized hosting, administering, and support
- added graphic for Sandstorm on Oasis
- added check & x-marks
- added tagline: "Run Sandstorm anywhere." (Open to suggestions) 
- removed Oasis section
- consolidated Oasis plans into one of the 3 product options
- changed description copy for each of the products
- changed Standard to Sandstorm Standard
- changed bottom "Questions?" call to action to "Let us help you get the most out of Sandstorm"
- colour-themed each of the products (bg colour and buttons)
- change /business so that "Core and Security" will say "Sandstorm Standard" and "Business" will say "Sandstorm for Work".
Note: I recognize that "Sandstorm for Enterprise" will be under "Sandstorm for Work" and I'm OK with this for now.
- on /features removed "Choose your host" section
- update footer links
- make sure it's mobile-friendly
- changed all /get# links to /get
- mentioned SAML
- get top coloured bg sections of each plan to maintain the same height as the others

![image](https://cloud.githubusercontent.com/assets/855341/18735984/2356f3ca-8037-11e6-8d90-7c30926e9dbc.png)

![image](https://cloud.githubusercontent.com/assets/855341/18730752/d402573a-800c-11e6-8bbe-1d816feeecd3.png)

![image](https://cloud.githubusercontent.com/assets/855341/18730450/3af9759c-800b-11e6-9978-b5823357b645.png)

Screenshot from before:

![image](https://cloud.githubusercontent.com/assets/855341/18728013/34325b9e-8000-11e6-8b42-ad7bd11aa491.png)
