### PR TITLE
Re-add Oasis pricing table

### DIFF
--- a/get.html
+++ b/get.html
@@ -17,7 +17,7 @@ title: Get Sandstorm
         <ul id="oasis">
           <li class="title"><strong>Sandstorm on Oasis</strong><p>Never worry about running servers—we'll host your Sandstorm for you.</p><img src="/images/get-oasis.svg">
           <div class="offer"></div>
-          <li class="price"><strong>$0-$24</strong><br>/ user / month - billed monthly</strong>
+          <li class="price"><strong>$0-$24</strong><br>/ user / month - <a class="pricing-button" href="#oasis-pricing">See Pricing</a>
           <li class="features">
           <ul class="highlight">
             <li>Sandstorm.io-hosted
@@ -128,3 +128,71 @@ title: Get Sandstorm
   <li>Let us help you get the most out of Sandstorm
   </li><a href="mailto:contact@sandstorm.io">E-mail us</a>
 </div>
+
+<div id="oasis-pricing" class="overlay">
+  <div class="popup"><a class="close" href="#">&times;</a>
+    <div class="content">
+      <section id="managed-hosting">
+       <h1>Sandstorm on Oasis: Hosting by Sandstorm.io</h1>
+       <h2>Which plan is right for you?</h2>
+       <ul class="oasis-plans">
+           <li class="oasis-plan">
+             <ul id="free">
+               <li class="title"><strong>Free</strong>
+                   <br>Start here</li>
+               <li class="price"><strong>$0</strong>
+                   <br>/forever</li>
+               <li class="storage"><strong>200MB</strong>
+                   <br>storage</li>
+               <li class="grains">5 grains</li>
+               <li class="get"><a href="https://oasis.sandstorm.io/">Get Free</a></li>
+             </ul>
+           </li>
+           <li class="oasis-plan">
+             <ul id="basic">
+               <li class="title"><strong>Basic</strong>
+                   <br>Just what you need</li>
+               <li class="price"><strong>$9</strong>
+                   <br>/month</li>
+               <li class="storage"><strong>10GB</strong>
+                   <br>storage</li>
+               <li class="grains">Unlimited grains</li>
+               <li class="get"><a href="https://oasis.sandstorm.io/">Get Standard</a></li>
+             </ul>
+           </li>
+           <li class="oasis-plan">
+             <ul id="power">
+               <li class="title"><strong>Power User</strong>
+                   <br>Boost your productivity</li>
+               <li class="price"><strong>$24</strong>
+                   <br>/month</li>
+               <li class="storage"><strong>100GB</strong>
+                   <br>storage</li>
+               <li class="grains">Unlimited grains</li>
+                 <li class="get"><a href="https://oasis.sandstorm.io/">Get Power-User</a></li>
+             </ul>
+           </li>
+        </ul>
+        
+        <div id="faq">
+        <h2>Details</h2>
+        <hr>
+          <h4>All about grains</h4>
+          <p>A grain is a document, chat room, mail box, notebook, blog, or anything else you create. A 5-grain limit applies to accounts on the Free plan.</p>
+          <h4>Resource limits</h4>
+          <p>Sandstorm apps only use RAM while you are using them. Sandstorm uses <a href="https://sandstorm.io/news/2015-01-14-compute-units">compute units</a> as a measurement of sustained RAM usage over a month. Basic and Power User plans come with 600 compute units, which is more than most users need. Free plans come with 20 compute units.</p>
+        </div>
+        
+      </section>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+  /* Javascript to support the Oasis pricing table. */
+  var disableBodyScroll = function() { document.body.classList.add("no-vertical-scroll"); };
+  var enableBodyScroll = function() { document.body.classList.remove("no-vertical-scroll"); };
+  var adjustBodyScroll = function() { if (location.hash.includes("oasis-pricing")) { disableBodyScroll(); } else { enableBodyScroll(); } };
+  adjustBodyScroll();
+  window.addEventListener("hashchange", adjustBodyScroll, false);
+</script>

--- a/style.scss
+++ b/style.scss
@@ -80,6 +80,10 @@ $lightpurple-text: #d7c4f4;
   box-sizing: border-box;
 }
 
+.no-vertical-scroll {
+  overflow-y: hidden;
+}
+
 body {
   background-color: white;
   font-family: "Source Sans Pro", sans-serif;
@@ -1483,7 +1487,7 @@ body >footer {
     }
   }
   
-  #oasis {
+  #oasis, #managed-hosting {
     .title {
       background-color: #f5edfd;
     }
@@ -1497,6 +1501,197 @@ body >footer {
       }
     }
   }
+  
+// =======================================================================================
+// Oasis pricing tables on get.html
+
+  .box {
+    width: 40%;
+    margin: 0 auto;
+    padding: 35px;
+    border: 2px solid #fff;
+    border-radius: 25px/50px;
+    background: rgba(255,255,255,0.3);
+    background-clip: padding-box;
+    text-align: center;
+  }
+
+  .pricing-button {
+    padding: 2px 4px;
+    border-radius: 5px;
+    background: #f5edfd;
+    cursor: pointer;
+    transition: all 0.3s ease-out;
+  }
+  .pricing-button:hover {
+    background: #fbf6ff;
+  }
+
+  .popup {
+    position: relative;
+    margin: 50px auto;
+    padding: 20px;
+    border-radius: 5px;
+    background: #fff;
+    width: 80%;
+    max-width: 850px;
+    transition: all 4s ease-in-out;
+    
+    @media (max-width: 800px) {
+     width: 95%; 
+    }
+    
+    @media (max-width: 500px) {
+      width: 100%;
+    }
+    
+    .content {
+      max-height: 80%;
+      overflow: hidden;
+    }
+    .close {
+      text-decoration: none;
+      position: absolute;
+      font-size: 35px;
+      font-weight: 400;
+      top: 20px;
+      right: 30px;
+      transition: all 200ms; 
+    }    
+    .close:hover {
+      color: #684599;
+    }
+  }
+  
+  .overlay {
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    visibility: hidden;
+    opacity: 0;
+    background: rgba(0, 0, 0, 0.6);
+    z-index: 10;
+    overflow: scroll;
+    max-width: 100%;
+  }
+  .overlay:target {
+    opacity: 1;
+    visibility: visible;
+  }
+  
+  #managed-hosting {
+    padding: 0 20px;
+    @media (max-width: 750px) {
+      padding: 0 10px;
+    }
+    
+    h1 {
+      font-size: 30px;
+      font-weight: 400;
+      padding-top: 20px;
+      @media (max-width: 500px) {
+        font-size: 25px;
+      }
+    }
+    
+    h2, h3 {
+      text-align: center;
+    }
+    ul {
+      list-style: none;
+      padding-left: 0;
+      width: 100%;
+    }
+    .oasis-plans {
+      width: 100%;
+      display: inline-flex;
+      justify-content: space-around;
+      flex-wrap: wrap;
+      #basic {
+        border: 1px solid #b6a1cd;
+        border-radius: 5px;
+      }
+      .oasis-plan {
+        display: flex;
+        border-radius: 5px;
+        border: 1px solid #ccc;
+        width: 31%;
+        margin: 0 5px 10px 5px;
+        @media (max-width: 650px) {
+          width: 46%;
+        }
+        @media (max-width: 500px) {
+          width: 95%;
+        }
+        li {
+          text-align: center;
+          padding: 10px 0;
+          border-bottom: 1px solid #dbcdea;
+        }
+        .title {
+          border-radius: 5px 5px 0px 0px;
+          @media (max-width: 750px) and (min-width: 650px) {
+            font-size: 15px;
+          }
+          strong {
+            font-size: 30px;
+            @media (max-width: 750px) and (min-width: 650px) {
+              font-size: 20px;
+            }
+          }
+        }
+        .price {
+          strong {
+            font-size: 25px;
+          }
+        }
+        .storage {
+          strong {
+            font-size: 25px;
+          }
+        }
+        .grains {
+
+        }
+        .get {
+          border-bottom: 0px;
+          border-radius: 0px 0px 5px 5px;
+          padding: 12px 0;
+          display: flex;
+          >a {
+            text-decoration: none;
+            color: white;
+            font-size: 20px;
+            border-radius: 5px;
+            width: 90%;
+            padding: 10px 0;
+            transition: transform 0.75s ease, background 0.35s ease;
+            margin: 0 auto;
+          }
+        }
+      }
+    }
+    
+    #faq {
+      padding-bottom: 20px;
+      h2 {
+        padding-top: 0;
+      }
+      li, p {
+        font-size: 16px;
+      }
+      hr {
+        border: 0;
+        border-top: 1px solid #ccc;
+      }
+    }
+  }
+  
+// =======================================================================================
 
   #plan-table {
     text-align: center;
@@ -3432,4 +3627,3 @@ body >footer {
     }
   }
 }
-


### PR DESCRIPTION
Copy is ready for review; styling still needs some work.

In this PR:
- added a "See Pricing" button that displays a popup when clicked
- added a popup that displays the Oasis pricing table

Remaining to dos:
- [x] make it mobile-friendly
- [x] ask Asheesh to set "overflow-y: hidden" on the body element when the overlay is displayed

Not in this PR:
- I think we should also communicate the benefits of using Oasis on this popup but I'll create a separate PR for that so as to not block this PR.

![oasis-hostingbysandstormio](https://cloud.githubusercontent.com/assets/855341/19136853/a72d4b5c-8b24-11e6-81e7-8d0da992fed1.jpg)

