### PR TITLE
Education landing page copy changes

### DIFF
--- a/go/education.html
+++ b/go/education.html
@@ -10,7 +10,7 @@ title: Education
 </header>
 
 <script type="text/javascript">
-var appCount = "Dozens of";
+var appCount = "dozens of";
 
 (function () {
   // Fetch the app list so that we can display the number of apps currently in the
@@ -31,41 +31,42 @@ var appCount = "Dozens of";
 
 <section id="web-apps">
   <h2>Why use Sandstorm?</h2>
-    <h3>University IT teams around the world are installing Sandstorm, an open source dashboard for productivity tools, hosted within the institution.
-
-    Web productivity tools are a few clicks away for educators and students. Enjoy the <script type="text/javascript">document.write(appCount)</script>+ apps in the Sandstorm App Market, all pre-approved, or add custom apps.</h3>
-  
+    <h3>
+      Universities around the world are using collaboration tools on Sandstorm. With a few clicks students and faculty can enjoy  <a href="https://apps.sandstorm.io"><script type="text/javascript">document.write(appCount)</script>+ productivity web apps</a>, all pre-approved, or add their own custom apps.
+    </h3>
   <ul>
     
-    <li class="publish-online">
-      <h3>Publish online</h3>
-      <p>With <a href="https://apps.sandstorm.io/app/aax9j672p6z8n7nyupzvj2nmumeqd4upa0f7mgu8gprwmy53x04h">WordPress</a></p>
+    <li class="sync-and-share-files">
+      <h3>Sync and share files</h3>
+      <p>With <a href="https://apps.sandstorm.io/app/8aspz4sfjnp8u89000mh2v1xrdyx97ytn8hq71mdzv4p4d8n0n3h">Davros</a></p>
       
     <li class="typeset-papers">
-      <h3>Typeset papers</h3>
-      <p>With <a href="https://apps.sandstorm.io/app/5vuv7v0w7gu20z72m78n83rx9qqtqpmtk32f39823wh967z226qh">ShareLaTeX</a></p>
+      <h3>Edit documents</h3>
+      <p>With <a href="https://apps.sandstorm.io/app/5vuv7v0w7gu20z72m78n83rx9qqtqpmtk32f39823wh967z226qh">ShareLaTeX</a>, <a href="https://apps.sandstorm.io/app/h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60">Etherpad</a></p>
       
     <li class="organize-projects">
       <h3>Organize projects</h3>
       <p>With <a href="https://apps.sandstorm.io/app/m86q05rdvj14yvn78ghaxynqz7u2svw6rnttptxx49g1785cdv1h">Wekan</a></p>
       
-    <li class="sync-and-share-files">
-      <h3>Sync and share files</h3>
-      <p>With <a href="https://apps.sandstorm.io/app/8aspz4sfjnp8u89000mh2v1xrdyx97ytn8hq71mdzv4p4d8n0n3h">Davros</a></p>
+    <li class="publish-online">
+      <h3>Publish online</h3>
+      <p>With <a href="https://apps.sandstorm.io/app/aax9j672p6z8n7nyupzvj2nmumeqd4upa0f7mgu8gprwmy53x04h">WordPress</a></p>
       
     <li class="access-one-place">
-      <h3>Access them all in one place with Sandstorm</h3>
+      <h3>Sign in once to access all web apps</h3>
       
     <li class="use-our-apps">
-      <h3>Use our <script type="text/javascript">document.write(appCount)</script>+ apps, or add custom apps</h3>
+      <h3>Use <a href="https://apps.sandstorm.io"><script type="text/javascript">document.write(appCount)</script>+ web apps</a>, or add custom apps</h3>
     
   </ul>
-  <p class="highlight">See our other great apps for calendars, diagrams, forums, and more on the <a href="http://apps.sandstorm.io">App Market</a>.</p>
+  <div class="action-ed">
+    <a href="http://apps.sandstorm.io">Visit the App Market</a><p>See great apps for calendars, diagrams, forums, and more.</p>
+  </div>
 </section>
 
 <section id="why-it">
   <h2>Here's why IT teams love it</h2>
-    <h3>Sandstorm comes with <script type="text/javascript">document.write(appCount)</script>+ great apps for every project. Instructors and students can also package their own apps that anyone can then install.</h3>
+    <h3>With a few clicks IT can pre-install any selection of apps from the <a href="https://apps.sandstorm.io">App Market</a>. Students and faculty can use any of these apps safely within Sandstorm.</h3>
   <ul>
     
     <li>
@@ -74,7 +75,7 @@ var appCount = "Dozens of";
       
     <li>
       <h3>Self-service software</h3>
-      <p>Sandstorm provides simple web access to every user at the institution. When you approve Sandstorm, users do what they want safely within Sandstorm, and they file fewer support tickets.</p>
+      <p>Sandstorm provides simple web access to every user at your institution. When you approve Sandstorm, users can use any app safely within Sandstorm, and will file fewer support tickets.</p>
 
     <li>
       <h3>Single-sign-on and web access</h3>
@@ -119,8 +120,8 @@ var appCount = "Dozens of";
 </section>
 <div class="action">  
   <h3>Use great web apps while keeping ownership of your data.</h3>
-  <p>Start your free 90-day trial today</p>
-  <a href="http://demo.sandstorm.io">Try a Quick Demo</a><a href="https://sandstorm.io/get-feature-key">Start Sandstorm setup</a>
+  <p>Start your free 60-day trial today</p>
+  <a href="http://demo.sandstorm.io">Try a Quick Demo</a><a href="https://sandstorm.io/get-feature-key">Start a free trial</a>
 </div>
 
 <section id="join-list">

--- a/style.scss
+++ b/style.scss
@@ -3351,7 +3351,7 @@ body >footer {
   p {
     &.highlight {
       text-align: center;
-      padding-bottom: 20px;
+      font-size: 20px;
     }
 
     &.copyright {
@@ -3542,6 +3542,49 @@ body >footer {
             background-color: #d1d1f5;
           }
         }
+      }
+    }
+    .action-ed {
+      padding-top: 35px;
+      padding-bottom: 15px;
+      display: block;
+      justify-content: center;
+      text-align: center;
+      a {
+        margin: 0 auto;
+        background-color: #d13f6c; 
+        border: 1.5px solid #eee9f4;
+        width: 300px;
+        display: block;
+        font-size: 25px;
+        padding: 8px 20px;
+        border-radius: 6px;
+        color: white;
+        transition: transform 0.75s ease, background 0.35s ease;
+        &:hover {
+          background-color: #e0507d;
+        }
+        @media (max-width: 500px) {
+          font-size: 22px;
+          width: 250px;
+        }
+      }
+      @include stripe {
+        background-color: #F6F2FC;
+      }
+      &:after {
+        display: block;
+        content: " ";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: calc(50% - 50vw);
+        width: 100vw;
+        z-index: -1;
+        background-color: #F6F2FC;
+        background-image: url(/images/market-tent.svg);
+        background-position: right bottom;
+        background-repeat: no-repeat;
       }
     }
   }


### PR DESCRIPTION
Still waiting for more feedback but I'll submit these changes for now. As soon as this gets merged & deployed I'll share it with more educators. :)

Changes in this PR:
- Changed the emphasis from installing Sandstorm to using Sandstorm in "Why use Sandstorm" sub header text
- App market link is a button now; also more app market links in general
- Changed sub header text for "Here's why IT teams love it" to focus more on what IT teams gain rather than repeating what instructors & students gain
- Changed bottom call-to-action "Start Sandstorm setup" text to "Start free trial"
- Other minor tweaks to copy (e.g. "the" -> "your")

After screenshot:
![go-education2](https://cloud.githubusercontent.com/assets/855341/19531909/414bd7d4-95ee-11e6-913d-2f3c7fd58b00.png)

Before screenshot: 
![go-education1](https://cloud.githubusercontent.com/assets/855341/19531404/662b3b3c-95ec-11e6-8cac-f329503d365b.png)