### PR TITLE
AWS button

### DIFF
--- a/install.html
+++ b/install.html
@@ -70,6 +70,10 @@ title: Install Sandstorm
       <p>For people as paranoid as we are...</p>
       <a href="https://docs.sandstorm.io/en/latest/install/#option-3-pgp-verified-install">See the docs »</a>
     </div>
+     <div class="aws section-content">
+      <h3>Amazon EC2 install</h3>
+       <a href="https://docs.sandstorm.io/en/latest/guided-tour/#create-a-virtual-machine-in-amazon-ec2">Begin install on AWS »</a>
+    </div>
   </section>
 
   <section>

--- a/style.scss
+++ b/style.scss
@@ -2796,6 +2796,11 @@ body >footer {
         width: 35%;
         margin-bottom: 0;
       }
+      >.aws {
+        float: right;
+        width: 35%;
+        margin-bottom: 0;
+      }
 
       &::after {
         content: " ";
@@ -2810,12 +2815,33 @@ body >footer {
         display: block;
         margin: 0 0 1em;
         background-color: #f0edf7;
-        font-size: 30px;
+        font-size: 28px;
         text-align: center;
         padding: 8px 0;
         text-decoration: none;
         color: #6A237C;
+        border-radius: 5px;
+        &:hover {
+          background-color: #e9e6f4;
+        }
       }
+    }
+    
+    >.aws {
+      >a {
+        display: block;
+        margin: 0 0 1em;
+        background-color: #f7981f;
+        font-size: 28px;
+        text-align: center;
+        padding: 8px 0;
+        text-decoration: none;
+        color: #fff;
+        border-radius: 5px;
+        &:hover {
+          background-color: #f28e22;
+        }
+      } 
     }
 
     pre {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/855341/20250141/e496035e-a9be-11e6-8827-bb8db737b2b3.png)

Perhaps we should add a string to provide more clarity? What are your thoughts on the copy @paulproteus?

White on the tangerine background might be a bit hard to see; it does match the AWS colours though. I might just style it as a regular button but have some AWS-styled image above.