### PR TITLE
Added App Market and Education links to footer

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -47,23 +47,18 @@
             <li><a href="/get">Sandstorm Standard</a>
             <li><a href="/get">Sandstorm for Work</a>
             <li><a href="https://github.com/sandstorm-io/sandstorm">Source Code (GitHub)</a>
+            <li><a href="/go/education">For Educators</a></li>
           </ul>
         </li>
         <li>
           <h3><a href="/features">Features</a></h3>
           <ul>
-            <li><a href="/features">Core</a>
-            <li><a href="/features#security">Security</a>
+            <li><a href="https://apps.sandstorm.io">App Market</a></li>
+            <li><a href="/features">Core features</a>
+            <li><a href="/features#security">Security features</a>
             <li><a href="/business">Sandstorm for Work</a>
             <li><a href="/business#scale">Sandstorm for Enterprise</a>
             <li><a href="/developer">Development</a>
-          </ul>
-        </li>
-        <li>
-          <h3><a href="/how-it-works">How it Works</a></h3>
-          <ul>
-            <li><a href="/how-it-works#grains">Fine-grained object containers</a>
-            <li><a href="/how-it-works#capabilities">Capability-based Security</a>
           </ul>
         </li>
         <li>
@@ -73,6 +68,13 @@
             <li><a href="https://docs.sandstorm.io/en/latest/developing/">Developer Hub</a>
             <li><a href="https://docs.sandstorm.io/en/latest/administering/">Administering &amp; installing</a>
             <li><a href="https://docs.sandstorm.io/en/latest/using/security-practices/">Security</a>
+          </ul>
+        </li>
+        <li>
+          <h3><a href="/how-it-works">How it Works</a></h3>
+          <ul>
+            <li><a href="/how-it-works#grains">Fine-grained object containers</a>
+            <li><a href="/how-it-works#capabilities">Capability-based Security</a>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
Also moved "Documentation" section so that it comes before "How it Works". Documentation information should be more accessible & visible.

It might be worthwhile to add any additional relevant links under "Documentation".
![image](https://cloud.githubusercontent.com/assets/855341/20316022/14d308d0-ab15-11e6-8ee1-a202ad4f228c.png)
