### PR TITLE
Fix typo that resulted in too few users in experimental condition

### DIFF
--- a/_includes/stats-support.js
+++ b/_includes/stats-support.js
@@ -108,7 +108,7 @@ var experiments = [
   {
     id: "install-screencast-autoplay",
     exp_range_start: 0,
-    exp_range_end: 0x1999999, // 10% of users
+    exp_range_end: 0x19999999, // 10% of users
     hook: function (userId, exp, inExperiment) {
       // Creates a stylesheet with a pair of classes that change the display: property,
       // allowing hiding of baseline content and showing of experimental content.


### PR DESCRIPTION
0x1999999 is much less than 0x19999999, but looks almost the same.
Hilariously, the example case has the appropriate number, but the actual
experiment definition lost a digit somewhere.  This resulted in ~1/16th
the expected number of users in the experimental condition as expected,
which means that we have very little experimental data.

*grumble* this sort of thing is exactly why I wanted this field to be a
membership fraction, not a large integer...