### PR TITLE
Don't show a double-border around the Basic plan.

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -1611,10 +1611,6 @@ body >footer {
       display: inline-flex;
       justify-content: space-around;
       flex-wrap: wrap;
-      #basic {
-        border: 1px solid #b6a1cd;
-        border-radius: 5px;
-      }
       .oasis-plan {
         display: flex;
         border-radius: 5px;


### PR DESCRIPTION
Not sure if this was intentional but it looks weird to me.

Before:

![screenshot from 2016-11-17 11-11-52](https://cloud.githubusercontent.com/assets/4001805/20403795/0d0bc972-acb7-11e6-8ce6-283f45844c31.png)

After:

![screenshot from 2016-11-17 11-12-16](https://cloud.githubusercontent.com/assets/4001805/20403805/128232d8-acb7-11e6-82be-c5869919733e.png)
