### PR TITLE
Add link stats recording to /get

### DIFF
--- a/_includes/stats.html
+++ b/_includes/stats.html
@@ -5,6 +5,7 @@ and stylesheets applied *before* the rest of the page renders, to prevent flash 
 unstyled content.
 -->
 {% endif %}
+<script src="/ga-helper.js"></script>
 <script>
 (function(){
 {% include stats-support.js %}

--- a/ga-helper.js
+++ b/ga-helper.js
@@ -1,0 +1,13 @@
+var trackOutboundLink = function(url, urlSuffix) {
+  var gaClickUrl = url;
+  if (urlSuffix) {
+    gaClickUrl = gaClickUrl + urlSuffix;
+  }
+  var followTheLink = function() { document.location = url; };
+  var doGaPing = window.ga && ga.create;
+  if (doGaPing) {
+    ga("send", "event", "outbound", "click", gaClickUrl, {"hitCallback": followTheLink});
+  } else {
+    followTheLink();
+  }
+};

--- a/get.html
+++ b/get.html
@@ -23,7 +23,10 @@ title: Get Sandstorm
             <li>Sandstorm.io-hosted
             <li>Administered by Sandstorm.io
             <li>Email support
-            <li class="get"><a href="https://oasis.sandstorm.io/">Sign up for Free</a>
+            <li class="get"><a
+                               onclick="trackOutboundLink('https://oasis.sandstorm.io/', '#get-oasis'); return false;"
+
+                               href="https://oasis.sandstorm.io/">Sign up for Free</a>
           </ul>
           <ul class="feature-list">
             <li class="list-title"><a href="/features">Sandstorm Standard features</a></li>
@@ -97,7 +100,10 @@ title: Get Sandstorm
             <li>Self-hosted
             <li>Administered by your IT team
             <li>Priority email support
-            <li class="get"><a href="https://sandstorm.io/get-feature-key">Start a Free Trial</a>
+            <li class="get"><a
+                               onclick="trackOutboundLink('https://sandstorm.io/get-feature-key'); return false;"
+
+                               href="https://sandstorm.io/get-feature-key">Start a Free Trial</a>
           </ul>
           <ul class="feature-list">
             <li class="list-title"><a href="/features">Sandstorm Standard features</a></li>
@@ -145,7 +151,9 @@ title: Get Sandstorm
                <li class="storage"><strong>200MB</strong>
                    <br>storage</li>
                <li class="grains">5 grains</li>
-               <li class="get"><a href="https://oasis.sandstorm.io/">Get Free</a></li>
+               <li class="get"><a
+                                  onclick="trackOutboundLink('https://oasis.sandstorm.io/', '#free-plan'); return false;"
+                                  href="https://oasis.sandstorm.io/">Get Free</a></li>
              </ul>
            </li>
            <li class="oasis-plan">
@@ -157,7 +165,9 @@ title: Get Sandstorm
                <li class="storage"><strong>10GB</strong>
                    <br>storage</li>
                <li class="grains">Unlimited grains</li>
-               <li class="get"><a href="https://oasis.sandstorm.io/">Get Standard</a></li>
+               <li class="get"><a
+                                  onclick="trackOutboundLink('https://oasis.sandstorm.io/', '#standard-plan'); return false;"
+                                  href="https://oasis.sandstorm.io/">Get Standard</a></li>
              </ul>
            </li>
            <li class="oasis-plan">
@@ -169,7 +179,9 @@ title: Get Sandstorm
                <li class="storage"><strong>100GB</strong>
                    <br>storage</li>
                <li class="grains">Unlimited grains</li>
-                 <li class="get"><a href="https://oasis.sandstorm.io/">Get Power-User</a></li>
+               <li class="get"><a
+                                  onclick="trackOutboundLink('https://oasis.sandstorm.io/', '#power-plan'); return false;"
+                                  href="https://oasis.sandstorm.io/">Get Power-User</a></li>
              </ul>
            </li>
         </ul>

--- a/install.html
+++ b/install.html
@@ -6,18 +6,6 @@ title: Install Sandstorm
 
 <!DOCTYPE html>
 
-<script type="text/javascript">
-  var trackOutboundLink = function(url) {
-  var followTheLink = function() { document.location = url; };
-  var doGaPing = window.ga && ga.create;
-  if (doGaPing) {
-  ga("send", "event", "outbound", "click", url, {"hitCallback": followTheLink});
-  } else {
-  followTheLink();
-  }
-  };
-</script>
-
 <header>
   <div>
     <h1>Sandstorm.io</h1>


### PR DESCRIPTION
I manually tested with the GA Debug tool that this retains the old behavior on /install and that the GA debug tool shows the right behavior on /get.
