### PR TITLE
Fix where the stripe overlay doesn't cover the whole screen

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -100,7 +100,9 @@ body {
   overflow-x: hidden;
 }
 
-body>* {
+body>nav, body>header, body>main, body>section, body>footer, body>div, body>span {
+  // The donation iframe needs to not get max-width: 1200px; applied to it, or the overlay will fail
+  // to cover other things.
   // 1px top padding prevents margin collapsing. We can't use overflow: hidden because it hides our
   // stripes.
   padding: 1px 30px 0;


### PR DESCRIPTION
Apparently given an inline style of width: 100% and a max-width: 1200px CSS
rule, the max-width rule wins.