### PR TITLE
Switch to Sandstorm-hosted Source Sans

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -16,7 +16,7 @@
       document.head.appendChild(viewportTag);
       window.onorientationchange = updateViewport;
     </script>
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,600' rel='stylesheet' type='text/css'>
+    <link href='https://sandstorm.io/fonts/sourcesans.css' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" media="screen" href="style.css">
 
     <title>Sandstorm Apps</title>

--- a/apps/style.css
+++ b/apps/style.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Open Sans",sans-serif;
+  font-family: "Source Sans Pro",sans-serif;
   font-weight: 300;
   font-size: 110%;
   line-height: 1.5;

--- a/cla/corporate.html
+++ b/cla/corporate.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,600' rel='stylesheet' type='text/css'>
+    <link href='https://sandstorm.io/fonts/sourcesans.css' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="style.css">
 
     <title>Sandstorm Corporate Contributor License Agreement</title>

--- a/cla/index.html
+++ b/cla/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,600' rel='stylesheet' type='text/css'>
+    <link href='https://sandstorm.io/fonts/sourcesans.css' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" media="screen" href="style.css">
 
     <title>Sandstorm Contributor License Agreements</title>

--- a/cla/individual.html
+++ b/cla/individual.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset='utf-8'>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,600' rel='stylesheet' type='text/css'>
+    <link href='https://sandstorm.io/fonts/sourcesans.css' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="style.css">
 
     <title>Sandstorm Individual Contributor License Agreement</title>

--- a/cla/style.css
+++ b/cla/style.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Open Sans",sans-serif;
+  font-family: "Source Sans Pro",sans-serif;
   font-weight: 300;
   font-size: 110%;
   line-height: 1.5;


### PR DESCRIPTION
This updates the CLA and old app list to use Source Sans instead of Open Sans, and removes the Google Fonts dependency from both.

Tried to use `../fonts/sourcesans.css` on my local, it didn't work. In particular, it seemed to correctly identify the CSS file, and attach it, but it didn't seem to find the fonts, as it used Arial. However, it did work when I explicitly specified the CSS file's location.