### PR TITLE
Remove Oasis "alternative" from the install page

### DIFF
--- a/install.html
+++ b/install.html
@@ -39,11 +39,6 @@ title: Install Sandstorm
       consider creating a 64-bit Ubuntu LTS virtual machine
       on your favorite cloud provider.
     </p>
-
-    <p>
-      Alternatively, you can let us run the server for you:
-      <a href="/get">Use Sandstorm Oasis</a>
-    </p>
   </section>
 
   <section>


### PR DESCRIPTION
Pointed out by slezyr on the HN thread.