### PR TITLE
Remove embed for non-existent demo video

### DIFF
--- a/install.html
+++ b/install.html
@@ -63,11 +63,6 @@ function onInstallMouseDown() {
       <p>The installer will offer you free dynamic DNS and valid HTTPS via <a href="https://sandcats.io">sandcats.io</a>,
         a service maintained by the Sandstorm development team.
 
-      <p>Here's what it looks like:</p>
-
-      <script type="text/javascript" src="https://asciinema.org/a/bw9mgfk8m55rfa3ntrfvhvjat.js"
-              id="asciicast-bw9mgfk8m55rfa3ntrfvhvjat" data-autoplay="true" async></script>
-
       <p>If you prefer more validation, you can
         <a href="https://docs.sandstorm.io/en/latest/install/#option-2-github-verified-install">download the install script from GitHub</a> or
         <a href="https://docs.sandstorm.io/en/latest/install/#option-4-installing-from-source">build from source</a>.


### PR DESCRIPTION
Fixes https://github.com/sandstorm-io/sandstorm/issues/3154

Asheesh added this originally, unless he has what he did, we'd have to recreate it. I am not sure if we recreated it using a third party embed is our best choice here anyways. I propose we just drop this for now.