### PR TITLE
Get rid of some no-longer relevant social media buttons.

### DIFF
--- a/community.html
+++ b/community.html
@@ -19,14 +19,12 @@ We're so glad you're interested in getting involved! We're a movement of app mak
   <h2>Connect with us</h2>
   <ul id="socialmedia">
     <li><a class="twitter" href="https://twitter.com/SandstormIO">Twitter</a>
-    <li><a class="google" href="https://plus.google.com/+SandstormIo">Google</a>
     <li><a class="facebook" href="https://www.facebook.com/sandstorm.io">Facebook</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
     <li><a class="livechat" href="https://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm">Live Chat</a>
     <li><a class="inperson" href="http://sandstorm.meetup.com/">In Person</a>
     <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
     <li><a class="youtube" href="https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg">YouTube</a>
-    <li><a class="linkedin" href="https://www.linkedin.com/company/sandstorm.io">LinkedIn</a>
   </ul>
 </section>
 

--- a/style.scss
+++ b/style.scss
@@ -457,7 +457,6 @@ body >footer {
 			}
 
 			&.twitter::before { content: "\e908"; }
-			&.google::before { content: "\e904"; }
 			&.facebook::before { content: "\e902"; }
 			&.github::before { content: "\e903"; }
 			}
@@ -2284,14 +2283,12 @@ body >footer {
             }
 
             &.twitter::before { content: "\e908"; }
-            &.google::before { content: "\e904"; }
             &.facebook::before { content: "\e902"; }
             &.github::before { content: "\e903"; }
             &.livechat::before { content: "\e905"; }
             &.inperson::before { content: "\e907"; }
             &.devgroup::before { content: "\e901"; }
             &.youtube::before { content: "\e909"; }
-            &.linkedin::before { content: "\e910"; }
           }
         }
       }
@@ -2752,14 +2749,12 @@ body >footer {
 				}
 
 				&.twitter::before { content: "\e908"; }
-				&.google::before { content: "\e904"; }
 				&.facebook::before { content: "\e902"; }
 				&.github::before { content: "\e903"; }
 				&.livechat::before { content: "\e905"; }
 				&.inperson::before { content: "\e907"; }
 				&.devgroup::before { content: "\e901"; }
 				&.youtube::before { content: "\e909"; }
-				&.linkedin::before { content: "\e910"; }
 			}
 			a:hover:before {
 				color: $purple-highlight;


### PR DESCRIPTION
- Google+ has shut down.
- It probably doesn't make sense to point to LinkedIn, since Sandstorm
  is no longer a business.