### PR TITLE
Add author name to RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -3,7 +3,7 @@ layout: none
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
 		<title>Sandstorm.io Blog</title>
 		<description>Latest updates on Sandstorm.io</description>		

--- a/feed.xml
+++ b/feed.xml
@@ -15,6 +15,7 @@ layout: none
 				<description>{{ post.content | xml_escape }}</description>
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
                                 <link>https://sandstorm.io{{ post.url }}</link>
+                                <dc:creator>{{ post.author | xml_escape }}</dc:creator>
                                 <guid isPermaLink="true">https://sandstorm.io{{ post.url }}</guid>
 			</item>
 		{% endfor %}


### PR DESCRIPTION
Fixes #326. I haven't tested this yet (I've not tried building the Sandstorm website before), but as long as the author information listed at the top of posts is available to what builds this feed, I assume this should work?

I did some research, because I want to use the information already provided in our posts, which doesn't include email addresses. I looked at a bunch of RSS feeds I follow, and noticed that very few actually use the optional field `<author>`, which requires an email address be provided. Many use `<dc:creator>`, which is less strict, see https://www.rssboard.org/rss-profile#namespace-elements-dublin-creator