### PR TITLE
Update community page with new IRC links

### DIFF
--- a/_posts/2020-02-03-reviving-sandstorm.md
+++ b/_posts/2020-02-03-reviving-sandstorm.md
@@ -66,7 +66,7 @@ in terms of development:
 As a community we're once again very hopeful, and I personally am
 committed to spending what time I can making Sandstorm's vision a
 reality. If you want to help, join us in the #sandstorm IRC channel
-on Freenode, and sign up for the [sandstorm-dev mailing list][8].
+on libera.chat, and sign up for the [sandstorm-dev mailing list][8].
 
 [1]: https://sandstorm.io/news/2017-02-06-sandstorm-returning-to-community-roots
 [2]: https://sandstorm.io/news/2017-10-28-i18n

--- a/_posts/2020-08-08-tiny-tiny-rss-and-the-powerbox.md
+++ b/_posts/2020-08-08-tiny-tiny-rss-and-the-powerbox.md
@@ -64,7 +64,7 @@ prompting the user for a feed URL and then trying to fetch it (causing
 the daemon to request access), it should just ask Sandstorm for a feed
 directly. If you're an enterprising PHP hacker and want to help make
 this happen, get in touch on the [sandstorm-dev mailing list][3] or the
-#sandstorm IRC channel on Freenode.
+#sandstorm IRC channel on libera.chat.
 
 [1]: https://github.com/zenhack/powerbox-http-proxy
 [2]: https://sandstorm.io/news/2015-06-10-network-access-permission-android-vs-sandstorm

--- a/community.html
+++ b/community.html
@@ -21,7 +21,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li><a class="twitter" href="https://twitter.com/SandstormIO">Twitter</a>
     <li><a class="facebook" href="https://www.facebook.com/sandstorm.io">Facebook</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
-    <li><a class="livechat" href="https://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm">Live Chat</a>
+    <li><a class="livechat" href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">Live Chat</a>
     <li><a class="inperson" href="http://sandstorm.meetup.com/">In Person</a>
     <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
     <li><a class="youtube" href="https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg">YouTube</a>
@@ -37,7 +37,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li class="talk"><h3>Give a Talk</h3>
       <p>Get started with our <a href="https://github.com/sandstorm-io/sandstorm/wiki/Speaker-Kit-Lightning-Talk">speaker kit</a> to prepare your presentation. <a href="https://groups.google.com/group/sandstorm-dev">Send us an email</a> if you need help with finding a venue or preparing for your talk. We'll also send you some sandcat stickers to give out!</p>
     <li class="discuss"><h3>Discuss &amp; Answer Questions</h3>
-      <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">sandstorm-dev group</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm">#sandstorm on freenode</a>), with <a href="https://freenode.irclog.whitequark.org/sandstorm/">chat archives available too.</a></p>
+      <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">sandstorm-dev group</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">#sandstorm on libera.chat</a>), with <a href="https://libera.irclog.whitequark.org/sandstorm/">chat archives available too.</a></p>
     <li class="build"><h3>Build a Local Community</h3>
       <p>If you're in San Francisco, meet core developers, app authors, and Sandstorm enthusiasts at the <a href="http://www.meetup.com/Sandstorm-SF-Bay-Area/">Sandstorm SF Bay Area meetup group</a>. You can also join or create a <a href="http://sandstorm.meetup.com/">meetup group near you</a>. <a href="https://groups.google.com/group/sandstorm-dev">Email us to get started.</a></p>
     <li class="write"><h3>Write a Blog Post</h3>
@@ -48,7 +48,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
   <h2>Help the project</h2>
   <ul>
     <li class="package"><h3>Package an App</h3>
-      <p>Check out our <a href="https://docs.sandstorm.io/en/latest/vagrant-spk/packaging-tutorial/">tutorial</a> to get started packaging apps for the <a href="https://apps.sandstorm.io/">App Market</a>. If you get stuck, <a href="https://groups.google.com/group/sandstorm-dev"> email us</a> for help or hop on <a href="http://kiwiirc.com/client/irc.freenode.net/?channel=#sandstorm">IRC.</a></p>
+      <p>Check out our <a href="https://docs.sandstorm.io/en/latest/vagrant-spk/packaging-tutorial/">tutorial</a> to get started packaging apps for the <a href="https://apps.sandstorm.io/">App Market</a>. If you get stuck, <a href="https://groups.google.com/group/sandstorm-dev"> email us</a> for help or hop on <a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">IRC</a>.</p>
     <li  class="feedback"><h3>Provide Feedback</h3>
       <p>To provide suggestions for each app: visit the <a href="https://apps.sandstorm.io/">Sandstorm App Market</a>, click on the app, click on the app's Code link, then navigate to its issue tracker. You can report bugs in Sandstorm itself on our <a href="https://github.com/sandstorm-io/sandstorm/issues">issue tracker</a>.</p>
     <li class="design"><h3>Design App Icons</h3>

--- a/community.html
+++ b/community.html
@@ -22,7 +22,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li><a class="facebook" href="https://www.facebook.com/sandstorm.io">Facebook</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
     <li><a class="livechat" href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">Live Chat</a>
-    <li><a class="inperson" href="http://sandstorm.meetup.com/">In Person</a>
+    <li><a class="inperson" href="https://sandstorm.meetup.com/">In Person</a>
     <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
     <li><a class="youtube" href="https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg">YouTube</a>
     <li><a class="linkedin" href="https://www.linkedin.com/company/sandstorm.io">LinkedIn</a>
@@ -37,9 +37,9 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li class="talk"><h3>Give a Talk</h3>
       <p>Get started with our <a href="https://github.com/sandstorm-io/sandstorm/wiki/Speaker-Kit-Lightning-Talk">speaker kit</a> to prepare your presentation. <a href="https://groups.google.com/group/sandstorm-dev">Send us an email</a> if you need help with finding a venue or preparing for your talk. We'll also send you some sandcat stickers to give out!</p>
     <li class="discuss"><h3>Discuss &amp; Answer Questions</h3>
-      <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">sandstorm-dev group</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">#sandstorm on libera.chat</a>), with <a href="https://libera.irclog.whitequark.org/sandstorm/">chat archives available too.</a></p>
+      <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">sandstorm-dev group</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">#sandstorm on libera.chat</a>), with <a href="https://libera.irclog.whitequark.org/sandstorm/">chat archives</a> available too.</p>
     <li class="build"><h3>Build a Local Community</h3>
-      <p>If you're in San Francisco, meet core developers, app authors, and Sandstorm enthusiasts at the <a href="http://www.meetup.com/Sandstorm-SF-Bay-Area/">Sandstorm SF Bay Area meetup group</a>. You can also join or create a <a href="http://sandstorm.meetup.com/">meetup group near you</a>. <a href="https://groups.google.com/group/sandstorm-dev">Email us to get started.</a></p>
+      <p>You can join or create a <a href="https://sandstorm.meetup.com/">meetup group</a> near you. <a href="https://groups.google.com/group/sandstorm-dev">Email us</a> to get started.</p>
     <li class="write"><h3>Write a Blog Post</h3>
       <p>Share your Sandstorm experiences with the world by writing a blog post. Send us a link and we'll share it with the community. <a href="https://groups.google.com/group/sandstorm-dev">Email us</a> if you need topic ideas.</p>
   </ul>
@@ -54,7 +54,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li class="design"><h3>Design App Icons</h3>
       <p>Many apps packaged for Sandstorm need icons and design help. If you have design skills and would love to help improve apps, <a href="https://groups.google.com/group/sandstorm-dev">send us an e-mail</a> and we'll connect you with apps in need.</p>
     <li class="usability"><h3>Usability Test</h3>
-      <p>Usability tests are a great way to identify user problems and areas for improvement. Find volunteers, record them as they try Sandstorm, review the videos, then <a href="https://github.com/sandstorm-io/sandstorm/issues">file issues</a>. For more help read <a href="http://www.nngroup.com/articles/usability-101-introduction-to-usability/">Usability 101</a> by Jakob Nielsen and <a href="https://groups.google.com/group/sandstorm-dev">e-mail us</a> for tips.</p>
+      <p>Usability tests are a great way to identify user problems and areas for improvement. Find volunteers, record them as they try Sandstorm, review the videos, then <a href="https://github.com/sandstorm-io/sandstorm/issues">file issues</a>. For more help read <a href="https://www.nngroup.com/articles/usability-101-introduction-to-usability/">Usability 101</a> by Jakob Nielsen and <a href="https://groups.google.com/group/sandstorm-dev">e-mail us</a> for tips.</p>
     <li class="documentation"><h3>Improve the Documentation</h3>
       <p>The <a href="https://docs.sandstorm.io/">Sandstorm documentation</a> lives in the <a href="https://github.com/sandstorm-io/sandstorm/tree/master/docs">main GitHub repository</a> for Sandstorm. Listen to IRC and the dev group, identify a common question, then submit a pull request.</p>
     <li class="core"><h3>Contribute to the Core</h3>


### PR DESCRIPTION
So, as things have escalated, note that Whitequark has stopped servicing Freenode, which places us in a bit of a "if a tree falls in the forest and nobody can hear it, does it make a sound" problem. This is the PR to redirect new people to join us on Libera instead, where we are registered and Whitequark is logging us.

Some additional thoughts:
- I've left KiwiIRC as the web client for now, but we may need to change this in the near future, as it's owner has abandoned all things IRC. They said they intend to hand it off at some point, but who to, who knows.
- A lot of our blog posts include mention of our IRC. Should we consider those historical and leave them, or should we update them to ensure nobody reading about us ends up in the wrong place? I think updating them on the blog is probably the right thing to do, if you agree, I will add a commit here.

cc: @zenhack @kentonv for opinions