### PR TITLE
Remove "behind the firewall" in og:description / social media preview.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,7 +10,7 @@
     <meta property="og:image" content="{% if page.imageUrl %}{{page.imageUrl}}{% else %}https://sandstorm.io/images/sandcat.png{% endif %}">
     <meta property="og:url" content="https://sandstorm.io{{page.url}}">
     <meta property="og:description"
-        content="Real-time collaborative web productivity suite behind the firewall.">
+        content="Take control of your web by running your own personal cloud server with Sandstorm.">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="alternate" type="application/rss+xml" title="Sandstorm.io Blog" href="{{site.baseurl}}feed.xml">
   </head>


### PR DESCRIPTION
This reverts commit 7e8a2fd5e4c27d796fbc495168e2c42d6729f9d8.

The rest of the website is no longer pitching to business intranet use cases, so this shouldn't either.