### PR TITLE
Community: Remove LinkedIn and Meetup

### DIFF
--- a/community.html
+++ b/community.html
@@ -22,10 +22,8 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li><a class="facebook" href="https://www.facebook.com/sandstorm.io">Facebook</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
     <li><a class="livechat" href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">Live Chat</a>
-    <li><a class="inperson" href="https://sandstorm.meetup.com/">In Person</a>
     <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
     <li><a class="youtube" href="https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg">YouTube</a>
-    <li><a class="linkedin" href="https://www.linkedin.com/company/sandstorm.io">LinkedIn</a>
   </ul>
 </section>
 
@@ -38,10 +36,8 @@ We're so glad you're interested in getting involved! We're a movement of app mak
       <p>Get started with our <a href="https://github.com/sandstorm-io/sandstorm/wiki/Speaker-Kit-Lightning-Talk">speaker kit</a> to prepare your presentation. <a href="https://groups.google.com/group/sandstorm-dev">Send us an email</a> if you need help with finding a venue or preparing for your talk. We'll also send you some sandcat stickers to give out!</p>
     <li class="discuss"><h3>Discuss &amp; Answer Questions</h3>
       <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">sandstorm-dev group</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">#sandstorm on libera.chat</a>), with <a href="https://libera.irclog.whitequark.org/sandstorm/">chat archives</a> available too.</p>
-    <li class="build"><h3>Build a Local Community</h3>
-      <p>You can join or create a <a href="https://sandstorm.meetup.com/">meetup group</a> near you. <a href="https://groups.google.com/group/sandstorm-dev">Email us</a> to get started.</p>
     <li class="write"><h3>Write a Blog Post</h3>
-      <p>Share your Sandstorm experiences with the world by writing a blog post. Send us a link and we'll share it with the community. <a href="https://groups.google.com/group/sandstorm-dev">Email us</a> if you need topic ideas.</p>
+      <p>Share your Sandstorm experiences with the world by writing a blog post. Send us a link and we'll share it with the community.</p>
   </ul>
 </section>
 <section id="helpproject">

--- a/style.scss
+++ b/style.scss
@@ -2132,7 +2132,7 @@ body >footer {
     }
 
 		li {
-			width: 11%;
+			width: 16.5%;
 			display: inline-block;
 
 


### PR DESCRIPTION
LinkedIn is kinda irrelevant here, and our Meetup presence has long since gone away (the URL just loads the Meetup home page). I think we should simply drop both. Looking at Facebook, and the messages that have been sent at it in the past couple years... we might want to keep that open, I think, but I don't know. Fixes #336.

Going to play with the centering too, Cloudflare Pages makes this fun I think?