### PR TITLE
Remove footer link to deleted section

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -53,7 +53,6 @@
             <li><a href="https://apps.sandstorm.io">App Market</a></li>
             <li><a href="/features">Core features</a>
             <li><a href="/features#security">Security features</a>
-            <li><a href="/business#scale-features">Scale-out</a>
             <li><a href="/business">For organizations</a>
             <li><a href="/developer">For developers</a>
           </ul>


### PR DESCRIPTION
In #328, Ian deleted the scale-out section of the business page, so we definitely don't need a footer link to it.