### PR TITLE
Add help to top of install

### DIFF
--- a/install.html
+++ b/install.html
@@ -40,6 +40,12 @@ title: Install Sandstorm
       on your favorite cloud provider.
     </p>
   </section>
+  
+  <section class="intro">
+    <p>
+      <strong>Having trouble?</strong> Check our <a href="https://docs.sandstorm.io/en/latest/administering/faq/">FAQ</a>, or <a href="/community">connect with us</a>!
+    </p>
+  </section>
 
   <section>
     <h2>1. Download & run the installer</h2>


### PR DESCRIPTION
I think this fixes #346 adequately, though I am unhappy with the destination. The FAQ link here would've told @jdougan about the memory issues, but we have a *different* page which does not, for troubleshooting a new install! We probably should rework what is between these two pages.