### PR TITLE
Remove links to Facebook

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,6 @@
 <div class="sidebar">
   <ul class="socialmedia">
     <li><a class="twitter" href="https://twitter.com/SandstormIO">Twitter</a>
-    <li><a class="facebook" href="https://www.facebook.com/sandstorm.io" target="blank">Facebook</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm" target="_blank">Github</a>
   </ul>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -95,7 +95,6 @@
           <h3>Connect</h3>
           <ul id="socialmedia-small">
 						<li><a class="twitter" href="https://twitter.com/SandstormIO"></a>
-						<li><a class="facebook" href="https://www.facebook.com/sandstorm.io" target="blank"></a>
 						<li><a class="github" href="https://github.com/sandstorm-io/sandstorm" target="_blank"></a>
   			</ul>
         </li>

--- a/community.html
+++ b/community.html
@@ -19,7 +19,6 @@ We're so glad you're interested in getting involved! We're a movement of app mak
   <h2>Connect with us</h2>
   <ul id="socialmedia">
     <li><a class="twitter" href="https://twitter.com/SandstormIO">Twitter</a>
-    <li><a class="facebook" href="https://www.facebook.com/sandstorm.io">Facebook</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
     <li><a class="livechat" href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">Live Chat</a>
     <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>

--- a/style.scss
+++ b/style.scss
@@ -2132,7 +2132,7 @@ body >footer {
     }
 
 		li {
-			width: 16.5%;
+			width: 20%;
 			display: inline-block;
 
 


### PR DESCRIPTION
This removes Facebook from the community page, as well as the footer and sidebar on every page.

I did leave this message on the page, though since it isn't from the page itself, it's on the "Community" tab of the page, as opposed to the front page. It does appear above any other user-submitted posts to the page though, so hopefully people considering posting there will see it.

![image](https://user-images.githubusercontent.com/4399499/172025155-0db150f7-0343-4136-8290-0e6ccf305e4d.png)
