### PR TITLE
Add link rel="me" for mastodon account.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,6 +13,7 @@
         content="Take control of your web by running your own personal cloud server with Sandstorm.">
     <link rel="stylesheet" type="text/css" href="/style.css">
     <link rel="alternate" type="application/rss+xml" title="Sandstorm.io Blog" href="{{site.baseurl}}feed.xml">
+    <link rel="me" href="https://floss.social/@sandstorm">
   </head>
 
 {% if layout.id %}


### PR DESCRIPTION
We just made an official mastodon account for the project; this patch adds the metadata link to "verify" the account.

Separately we should add it to the community page, but that requires mucking with fetching a logo and such, so I figured I'd go ahead with just this.